### PR TITLE
Use formatted exception instead of TestProblem for TAP

### DIFF
--- a/src/feditest/testrun.py
+++ b/src/feditest/testrun.py
@@ -187,7 +187,7 @@ class TapTestResultWriter:
                         print(f"not ok {test_id} - {test.name}")
                         print("  ---")
                         print("  problem: |")
-                        for line in str(problem).strip().split("\n"):
+                        for line in str(problem.exc).strip().split("\n"):
                             print(f"    {line}")
                         print("  ...")
                     else:


### PR DESCRIPTION
The issue was that I was formatting the TestProblem instead of the exception. I manually tested that str(problem.exc) for a hamcrest AssertionError is the same output as `hamcrest.core.string_description.tostring`. I also added a unit test for a hamcrest exception (versus some other kind of thrown from the test).

Closes #59. 