### PR TITLE
HTML results / report generator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "langcodes",
   "msgspec",
   "multidict",
+  "jinja2",
   "pyhamcrest",
   "pytest"
 ]

--- a/src/feditest/templates/report.jinja2
+++ b/src/feditest/templates/report.jinja2
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            margin: 2rem !important;
+            padding-right: 2rem;
+        }
+
+        .status.passed {
+            color: lightgreen;
+        }
+
+        .status.failed {
+            color: pink;
+        }
+
+        .session {
+            margin-bottom: 1rem;
+        }
+
+        .session > .name {
+            font-weight: bold;
+            color: lightblue;
+        }
+
+        .session > .name::before {
+            content: "Session: ";
+        }
+
+        .constellation {
+            margin-left: 1rem;
+        }
+
+        .constellation > .name::before {
+            content: "Constellation: ";
+        }
+
+        .roles {
+            display: flex;
+            gap: 1rem;
+            margin-left: 1rem;
+        }
+
+        .role > .name {
+            font-weight: bold;
+        }
+
+        .role > .name::before {
+            content: "Role: ";
+        }
+
+        .role > .driver::before {
+            content: "Driver: ";
+        }
+
+        .role > table.parameters {
+            font-size: 0.8rem;
+        }
+    </style>
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+    />
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+    />
+    <title>Feditest Test Report</title>
+</head>
+<body>
+    <h1>Feditest Report</h1>
+    <h2>Test Summary</h2>
+    {% include "test_summary.jinja2" %}
+    {% with session_links=true %}
+    <h2>Test Results</h2>
+    {% include "test_matrix.jinja2" %}
+    {% endwith %}
+    <h2>Session Details</h2>
+    {% include "session_details.jinja2" %}
+</body>
+</html>

--- a/src/feditest/templates/session_details.jinja2
+++ b/src/feditest/templates/session_details.jinja2
@@ -1,0 +1,38 @@
+
+<div class="sessions">
+    {% for run_session, plan_session in sessions %}
+    <div class="session" id="{{ run_session.name }}">
+        <div class="name">{{ run_session.name }}</div>
+        <div class="constellation">
+            {% set constellation = plan_session.constellation -%}
+            <div class="name">{{ constellation.name }}</div>
+            <div class="roles">
+                {% for role in constellation.roles -%}
+                <div class="role">
+                    <div class="name">{{ role.name }}</div>
+                    <div class="driver">{{ role.nodedriver }}</div>
+                    {%- if role.parameters %}
+                    <table class="parameters">
+                        <thead>
+                            <tr>
+                                <th>Key</th>
+                                <th>Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for key, value in role.parameters.items() -%}
+                            <tr>
+                                <td class="key">{{ key }}</td>
+                                <td class="key">{{ value }}</td>
+                            </tr>
+                        </tbody>
+                        {% endfor %}                    
+                    </table>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>

--- a/src/feditest/templates/test_matrix.jinja2
+++ b/src/feditest/templates/test_matrix.jinja2
@@ -1,0 +1,35 @@
+
+<table class="tests">
+    <thead>
+        <tr>
+            <th>Test</th>
+            {%- for run_session, plan_session in sessions %}
+            <th>
+                {%- if session_links -%}
+                <a href="#{{ run_session.name }}">{{ run_session.name }}</a>
+                {%- else -%}
+                {{ run_session.name }}
+                {%- endif -%}
+            </th>
+            {%- endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for test_spec in all_tests -%}
+        <tr>
+            <td class="name">{{ test_spec.name }}</td>
+            {%- for run_session, plan_session in sessions -%}
+                {% set problem = get_problem(run_session, test_spec) -%}
+                {% if test_spec.disabled -%}
+                    {% set status = "skipped" -%}
+                {% elif problem -%}
+                    {% set status = "failed" -%}
+                {% else -%}
+                    {% set status = "passed" -%}
+                {% endif %}
+            <td class="status {{ status }}">{{ status }}</td>
+            {%- endfor %}
+        </tr>   
+        {%- endfor %}
+    </tbody>
+</table>

--- a/src/feditest/templates/test_summary.jinja2
+++ b/src/feditest/templates/test_summary.jinja2
@@ -1,0 +1,28 @@
+<table class="summary">
+    <thead>
+        <tr>
+            <th>Status</th>
+            <th>Count</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Passed</td>
+            <td>{{ summary.passed }}</td>
+        </tr>
+        <tr>
+            <td>Failed</td>
+            <td>{{ summary.failed }}</td>
+        </tr>
+        <tr>
+            <td>Skipped</td>
+            <td>{{ summary.skipped }}</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <td>Total</td>
+            <td>{{ summary.total }}</td>
+        </tr>
+    </tfoot>
+</table>


### PR DESCRIPTION
This is an initial prototype of an HTML test report. It includes a summary section, a test matrix, and a session details section. These are coded so they can be easily used individually if, for example, you just want the test matrix.

You can see an example report at https://stevebate.net/feditest/report.html. I did minimal styling with this and it's not mobile ready (AFAIK). The report is primarily intended to provide a basis for further discussion.

The report is generated from a test plan that I created to test WebFinger against Mastodon, Pleroma, Akkoma and Threads.

There are obvious challenges we need to address. The  automatically-generated session names are not very report-friendly. There are client/server roles (vs leader/follower), but there are no nice report-friendly names for those roles to use in the text matrix column headers. For test failures, I'm not sure where to show the failure and/or error details.

We may need to revisit the command line arguments now that we have three output formats. For now, if both `--tap` and `--html` are specified then TAP will have priority. It seems better to have a `--result-format` argument that can take values like `tap`, `default`, `html`, or whatever we or others add in the future.