### PR TITLE
Allow uppercase letters in account URIs

### DIFF
--- a/src/feditest/utils.py
+++ b/src/feditest/utils.py
@@ -3,20 +3,20 @@ Utility functions
 """
 
 import glob
-from importlib.metadata import version
 import importlib.util
 import pkgutil
 import re
 import sys
+from importlib.metadata import version
 from types import ModuleType
 from urllib.parse import urlparse
-from langcodes import Language
 
+from langcodes import Language
 
 FEDITEST_VERSION = version('feditest')
 
 # From https://datatracker.ietf.org/doc/html/rfc7565#section-7, but simplified
-ACCT_REGEX = re.compile(r"acct:([-a-z0-9\._~][-a-z0-9\._~!$&'\(\)\*\+,;=%]*)@([-a-z0-9\.:]+)")
+ACCT_REGEX = re.compile(r"acct:([-a-zA-Z0-9\._~][-a-zA-Z0-9\._~!$&'\(\)\*\+,;=%]*)@([-a-zA-Z0-9\.:]+)")
 
 
 def find_submodules(package: ModuleType) -> list[str]:


### PR DESCRIPTION
Closes #106.

This is causing some incorrect failures.

I only added uppercase letters to the regex. You probably know this, but the regex will allow invalid URIs for other reasons (e.g., `acct:foo@-:-`), but a completely correct regex for the hostname part of a URI is very complex. 