### PR TITLE
Unconfuse parse_validate API

### DIFF
--- a/src/feditest/nodedrivers/manual/__init__.py
+++ b/src/feditest/nodedrivers/manual/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 from feditest import nodedriver
 from feditest.protocols import Node, NodeDriver
 from feditest.protocols.fediverse import FediverseNode
-from feditest.utils import hostname_parse_validate
+from feditest.utils import hostname_validate
 
 
 class ManualFediverseNode(FediverseNode):
@@ -27,7 +27,7 @@ class ManualFediverseNodeDriver(NodeDriver):
         else:
             hostname = self.prompt_user(f'Manually provision a Node for constellation role "{ rolename }"'
                                         + ' and enter the hostname when done: ',
-                                        parse_validate=hostname_parse_validate)
+                                        parse_validate=hostname_validate)
             parameters = dict(parameters)
             parameters['hostname'] = hostname
 

--- a/src/feditest/nodedrivers/saas/__init__.py
+++ b/src/feditest/nodedrivers/saas/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 from feditest import nodedriver
 from feditest.protocols import NodeDriver
 from feditest.protocols.fediverse import FediverseNode
-from feditest.utils import hostname_parse_validate
+from feditest.utils import hostname_validate
 
 
 class SaasFediverseNode(FediverseNode):
@@ -24,7 +24,7 @@ class SaasFediverseNodeDriver(NodeDriver):
     def _provision_node(self, rolename: str, parameters: dict[str,Any]) -> SaasFediverseNode:
         hostname = parameters.get('hostname')
         if not hostname:
-            hostname = self.prompt_user(f'Enter the hostname for "{ rolename }": ', parse_validate=hostname_parse_validate)
+            hostname = self.prompt_user(f'Enter the hostname for "{ rolename }": ', parse_validate=hostname_validate)
             parameters= dict(parameters)
             parameters['hostname'] = hostname
 

--- a/src/feditest/protocols/activitypub/__init__.py
+++ b/src/feditest/protocols/activitypub/__init__.py
@@ -4,11 +4,12 @@ Abstractions for the ActivityPub protocol
 
 from typing import Any, cast
 
-from hamcrest import assert_that, is_not
+from hamcrest import is_not
 from feditest.protocols.activitypub.utils import is_member_of_collection_at
 
+from feditest import hard_assert_that
 from feditest.protocols.web import WebServer
-from feditest.utils import http_https_uri_parse_validate
+from feditest.utils import http_https_uri_validate
 
 
 class Actor:
@@ -68,12 +69,12 @@ class ActivityPubNode(WebServer):
             return cast(str, self.prompt_user(
                     f'Please enter an URI at Node "{self._rolename}" that serves an ActivityPub Actor document for the actor in role "{actor_rolename}": ',
                     self.parameter('node-uri'),
-                    http_https_uri_parse_validate))
+                    http_https_uri_validate))
 
         return cast(str, self.prompt_user(
                 f'Please enter an URI at Node "{self._rolename}" that serves an ActivityPub Actor document: ',
                 self.parameter('node-uri'),
-                http_https_uri_parse_validate))
+                http_https_uri_validate))
 
 
     def obtain_followers_collection_uri(self, actor_uri: str) -> str:
@@ -81,7 +82,8 @@ class ActivityPubNode(WebServer):
         Determine the URI that points to the provided actor's followers collection.
         """
         return cast(str, self.prompt_user(
-                f'Enter the URI of the followers collection of actor "{actor_uri}": ', parse_validate=http_https_uri_parse_validate))
+                f'Enter the URI of the followers collection of actor "{actor_uri}": ',
+                http_https_uri_validate))
 
 
     def obtain_following_collection_uri(self, actor_uri: str) -> str:
@@ -89,7 +91,8 @@ class ActivityPubNode(WebServer):
         Determine the URI that points to the provided actor's following collection.
         """
         return cast(str, self.prompt_user(
-                f'Enter the URI of the following collection of actor "{actor_uri}": ', parse_validate=http_https_uri_parse_validate))
+                f'Enter the URI of the following collection of actor "{actor_uri}": ',
+                http_https_uri_validate))
 
 
     def assert_member_of_collection_at(self, candidate_member_uri: str, collection_uri: str ):

--- a/src/feditest/protocols/web/__init__.py
+++ b/src/feditest/protocols/web/__init__.py
@@ -99,7 +99,10 @@ class WebClient(Node):
         """
         Make this WebClientperform an HTTP get on the provided uri.
         """
-        return self.http(HttpRequest(ParsedUri.parse(uri), 'GET' ), follow_redirects=follow_redirects)
+        parsed = ParsedUri.parse(uri)
+        if not parsed:
+            raise ValueError('Invalid URI:', uri)
+        return self.http(HttpRequest(parsed, 'GET' ), follow_redirects=follow_redirects)
 
 
     class TooManyRedirectsError(RuntimeError):

--- a/src/feditest/protocols/web/traffic.py
+++ b/src/feditest/protocols/web/traffic.py
@@ -4,86 +4,9 @@ Abstract data types that capture what is exchanged over HTTP.
 
 from datetime import UTC, date, datetime
 from dataclasses import dataclass
-from typing import List
-from urllib.parse import ParseResult, parse_qs, urlparse
 from multidict import MultiDict
 
-class ParsedUri:
-    """
-    An abstract data type for URIs. We want it to provide methods for accessing parameters,
-    and so we don't use ParseResult. Also failed attempting to inherit from it.
-    """
-    def __init__(self, scheme: str, netloc: str, path: str, params: str, query: str, fragment: str):
-        self.scheme = scheme
-        self.netloc = netloc
-        self.path = path
-        self.params = params
-        self.query = query
-        self.fragment = fragment
-        self._query_params : dict[str,list[str]] | None = None
-
-
-    @staticmethod
-    def parse(url: str, scheme='', allow_fragments=True) -> 'ParsedUri':
-        """
-        The equivalent of urlparse(str)
-        """
-        parsed : ParseResult = urlparse(url, scheme, allow_fragments)
-        return ParsedUri(parsed.scheme, parsed.netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
-
-
-    def get_uri(self) -> str:
-        ret = f'{ self.scheme }:'
-        if self.netloc:
-            ret += f'//{ self.netloc}'
-        ret += self.path
-        if self.params:
-            ret += f';{ self.params}'
-        if self.query:
-            ret += f'?{ self.query }'
-        if self.fragment:
-            ret += f'#{ self.fragment }'
-        return ret
-
-
-    def has_query_param(self, name: str) -> bool:
-        self._parse_query_params()
-        if self._query_params:
-            return name in self._query_params
-        return False
-
-
-    def query_param_single(self, name: str) -> str | None:
-        self._parse_query_params()
-        if self._query_params:
-            found = self._query_params.get(name)
-            if found:
-                match len(found):
-                    case 1:
-                        return found[0]
-                    case _:
-                        raise RuntimeError(f'Query has {len(found)} values for query parameter {name}')
-        return None
-
-
-    def query_param_mult(self, name: str) -> List[str] | None:
-        self._parse_query_params()
-        if self._query_params:
-            return self._query_params.get(name)
-        return None
-
-
-    def __repr__(self):
-        return f'ParsedUri({ self.get_uri() })'
-
-
-    def _parse_query_params(self):
-        if self._query_params:
-            return
-        if self.query:
-            self._query_params = parse_qs(self.query)
-        else:
-            self._query_params = {}
+from feditest.utils import ParsedUri
 
 
 @dataclass

--- a/src/feditest/protocols/webfinger/__init__.py
+++ b/src/feditest/protocols/webfinger/__init__.py
@@ -9,7 +9,7 @@ from feditest.protocols import NotImplementedByNodeError
 from feditest.protocols.web import WebClient, WebServer
 from feditest.protocols.web.traffic import HttpRequestResponsePair
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
-from feditest.utils import http_https_acct_uri_parse_validate
+from feditest.utils import http_https_acct_uri_validate
 
 
 class WebFingerServer(WebServer):
@@ -25,17 +25,17 @@ class WebFingerServer(WebServer):
         return: the identifier
         """
         if nickname:
-            parsed = self.prompt_user(
+            ret = self.prompt_user(
                     f'Please enter the URI of an existing or new account for role "{nickname}" at Node "{self._rolename}" (e.g. "acct:testuser@example.local" ): ',
                     self.parameter('existing-account-uri'),
-                    http_https_acct_uri_parse_validate)
+                    http_https_acct_uri_validate)
         else:
-            parsed = self.prompt_user(
+            ret = self.prompt_user(
                     f'Please enter the URI of an existing or new account at Node "{self._rolename}" (e.g. "acct:testuser@example.local" ): ',
                     self.parameter('existing-account-uri'),
-                    http_https_acct_uri_parse_validate)
-        assert parsed
-        return parsed
+                    http_https_acct_uri_validate)
+        assert ret
+        return ret
 
 
     def obtain_non_existing_account_identifier(self, nickname: str | None = None ) -> str:
@@ -47,17 +47,17 @@ class WebFingerServer(WebServer):
         return: the identifier
         """
         if nickname:
-            parsed = self.prompt_user(
+            ret = self.prompt_user(
                     f'Please enter the URI of an non-existing account for role "{nickname}" at Node "{self._rolename}" (e.g. "acct:does-not-exist@example.local" ): ',
                     self.parameter('nonexisting-account-uri'),
-                    http_https_acct_uri_parse_validate)
+                    http_https_acct_uri_validate)
         else:
-            parsed = self.prompt_user(
+            ret = self.prompt_user(
                     f'Please enter the URI of an non-existing account at Node "{self._rolename}" (e.g. "acct:does-not-exist@example.local" ): ',
                     self.parameter('nonexisting-account-uri'),
-                    http_https_acct_uri_parse_validate)
-        assert parsed
-        return parsed
+                    http_https_acct_uri_validate)
+        assert ret
+        return ret
 
 
     def obtain_account_identifier_requiring_percent_encoding(self, nickname: str | None = None) -> str:

--- a/src/feditest/testplan.py
+++ b/src/feditest/testplan.py
@@ -8,7 +8,7 @@ from typing import Any
 import msgspec
 
 import feditest
-from feditest.utils import hostname_parse_validate
+from feditest.utils import hostname_validate
 
 
 class TestPlanError(RuntimeError):
@@ -54,7 +54,7 @@ class TestPlanConstellationRole(msgspec.Struct):
             hostname = self.parameters.get('hostname')
             if hostname:
                 if isinstance(hostname, str):
-                    if hostname_parse_validate(hostname) is None:
+                    if hostname_validate(hostname) is None:
                         raise TestPlanError(context_msg + f'Invalid hostname: "{ hostname }".')
                 else:
                     raise TestPlanError(context_msg + 'Invalid hostname: not a string')

--- a/src/feditest/ubos/__init__.py
+++ b/src/feditest/ubos/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from feditest.protocols import Node, NodeDriver, NodeSpecificationInsufficientError, NodeSpecificationInvalidError
 from feditest.reporting import info
-from feditest.utils import hostname_parse_validate
+from feditest.utils import hostname_validate
 
 
 class UbosNodeDriver(NodeDriver):
@@ -34,7 +34,7 @@ class UbosNodeDriver(NodeDriver):
             raise NodeSpecificationInsufficientError(self, 'Need parameter adminid for now') # FIXME: should get it from the JSON file
         if 'hostname' not in parameters:
             raise NodeSpecificationInsufficientError(self, 'Needs parameter hostname for now') # FIXME: should get it from the JSON file
-        if not hostname_parse_validate(parameters['hostname']):
+        if not hostname_validate(parameters['hostname']):
             raise NodeSpecificationInvalidError(self, 'hostname', parameters['hostname'])
         if 'sitejsonfile' in parameters:
             cmd = f"sudo ubos-admin deploy --file {parameters['sitejsonfile']}"

--- a/src/feditest/utils.py
+++ b/src/feditest/utils.py
@@ -2,6 +2,7 @@
 Utility functions
 """
 
+from abc import ABC, abstractmethod
 import glob
 import importlib.util
 import pkgutil
@@ -9,14 +10,125 @@ import re
 import sys
 from importlib.metadata import version
 from types import ModuleType
-from urllib.parse import urlparse
-
+from typing import List, Optional
+from urllib.parse import ParseResult, parse_qs, urlparse
 from langcodes import Language
 
 FEDITEST_VERSION = version('feditest')
 
 # From https://datatracker.ietf.org/doc/html/rfc7565#section-7, but simplified
 ACCT_REGEX = re.compile(r"acct:([-a-zA-Z0-9\._~][-a-zA-Z0-9\._~!$&'\(\)\*\+,;=%]*)@([-a-zA-Z0-9\.:]+)")
+
+
+class ParsedUri(ABC):
+    """
+    An abstract data type for URIs. We want it to provide methods for accessing parameters,
+    and so we don't use ParseResult. Also failed attempting to inherit from it.
+    Because the structure is so different, we have subtypes.
+    """
+    @staticmethod
+    def parse(url: str, scheme='', allow_fragments=True) -> Optional['ParsedUri']:
+        """
+        The equivalent of urlparse(str)
+        """
+        parsed : ParseResult = urlparse(url, scheme, allow_fragments)
+        if parsed.scheme == 'acct':
+            if match := ACCT_REGEX.match(url):
+                return ParsedAcctUri(match[1], match[2])
+        if len(parsed.scheme) and len(parsed.netloc) and len(parsed.path):
+            return ParsedNonAcctUri(parsed.scheme, parsed.netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+        return None
+
+
+    @abstractmethod
+    def get_uri(self) -> str:
+        ...
+
+
+class ParsedNonAcctUri(ParsedUri):
+    """
+    ParsedUris that are "normal" URIs such as http URIs.
+    """
+    def __init__(self, scheme: str, netloc: str, path: str, params: str, query: str, fragment: str):
+        self.scheme = scheme
+        self.netloc = netloc
+        self.path = path
+        self.params = params
+        self.query = query
+        self.fragment = fragment
+        self._query_params : dict[str,list[str]] | None = None
+
+
+    def get_uri(self) -> str:
+        ret = f'{ self.scheme }:'
+        if self.netloc:
+            ret += f'//{ self.netloc}'
+        ret += self.path
+        if self.params:
+            ret += f';{ self.params}'
+        if self.query:
+            ret += f'?{ self.query }'
+        if self.fragment:
+            ret += f'#{ self.fragment }'
+        return ret
+
+
+    def has_query_param(self, name: str) -> bool:
+        self._parse_query_params()
+        if self._query_params:
+            return name in self._query_params
+        return False
+
+
+    def query_param_single(self, name: str) -> str | None:
+        self._parse_query_params()
+        if self._query_params:
+            found = self._query_params.get(name)
+            if found:
+                match len(found):
+                    case 1:
+                        return found[0]
+                    case _:
+                        raise RuntimeError(f'Query has {len(found)} values for query parameter {name}')
+        return None
+
+
+    def query_param_mult(self, name: str) -> List[str] | None:
+        self._parse_query_params()
+        if self._query_params:
+            return self._query_params.get(name)
+        return None
+
+
+    def __repr__(self):
+        return f'ParsedNonAcctUri({ self.get_uri() })'
+
+
+    def _parse_query_params(self):
+        if self._query_params:
+            return
+        if self.query:
+            self._query_params = parse_qs(self.query)
+        else:
+            self._query_params = {}
+
+
+class ParsedAcctUri(ParsedUri):
+    """
+    ParsedUris that are acct: URIs
+    """
+    def __init__(self, user: str, host: str):
+        self.user = user
+        self.host = host
+
+
+    def get_uri(self) -> str:
+        return f'acct:{ self.user }@{ self.host }'
+
+
+    def __repr__(self):
+        return f'ParsedAcctUri({ self.get_uri() })'
+
 
 
 def find_submodules(package: ModuleType) -> list[str]:
@@ -60,69 +172,102 @@ def load_python_from(dirs: list[str], skip_init_files: bool) -> None:
             sys.path = sys_path_before
 
 
-def account_id_parse_validate(candidate: str) -> tuple[str,str] | None:
+def account_id_parse_validate(candidate: str) -> ParsedUri | None:
     """
     Validate that the provided string is of the form 'acct:foo@bar.com'.
-    return tuple of user, host if valid, None otherwise
+    return ParsedUri if valid, None otherwise
     """
-    match = ACCT_REGEX.match(candidate)
-    if match:
-        return (match.group(1) or "", match.group(2) or "")
+    parsed = ParsedUri.parse(candidate)
+    if isinstance(parsed,ParsedAcctUri):
+        return parsed
     return None
 
 
-def http_https_uri_parse_validate(candidate: str) -> str | None:
+def account_id_validate(candidate: str) -> str | None:
+    parsed = account_id_parse_validate(candidate)
+    if parsed:
+        return parsed.get_uri()
+    return None
+
+
+def http_https_uri_parse_validate(candidate: str) -> ParsedUri | None:
     """
     Validate that the provided string is a valid HTTP or HTTPS URI.
-    return: string if valid, None otherwise
+    return: ParsedUri if valid, None otherwise
     """
-    parsed = urlparse(candidate)
-    if parsed.scheme in ['http', 'https'] and len(parsed.netloc) > 0:
-        return candidate
+    parsed = ParsedUri.parse(candidate)
+    if isinstance(parsed, ParsedNonAcctUri) and parsed.scheme in ['http', 'https'] and len(parsed.netloc) > 0:
+        return parsed
     return None
 
 
-def http_https_root_uri_parse_validate(candidate: str) -> str | None:
+def http_https_uri_validate(candidate: str) -> str | None:
+    parsed = http_https_uri_parse_validate(candidate)
+    if parsed:
+        return parsed.get_uri()
+    return None
+
+
+def http_https_root_uri_parse_validate(candidate: str) -> ParsedUri | None:
     """
     Validate that the provided string is a valid HTTP or HTTPS URI without a path, query or
     fragment component
-    return: string if valid, None otherwise
+    return: ParsedUri if valid, None otherwise
     """
-    parsed = urlparse(candidate)
-    # FIXME: check that urlparse faithfully implements the relevant RFCs
-    if (parsed.scheme in ['http', 'https']
+    parsed = ParsedUri.parse(candidate)
+    if (isinstance(parsed, ParsedNonAcctUri) and parsed.scheme in ['http', 'https']
             and len(parsed.netloc) > 0
             and (len(parsed.path) == 0 or parsed.path == '/')
             and len(parsed.params) == 0
             and len(parsed.query) == 0
             and len(parsed.fragment) == 0):
-        return candidate
+        return parsed
     return None
 
 
-def http_https_acct_uri_parse_validate(candidate: str) -> str | None:
+def http_https_root_uri_validate(candidate: str) -> str | None:
+    parsed = http_https_root_uri_parse_validate(candidate)
+    if parsed:
+        return parsed.get_uri()
+    return None
+
+
+def http_https_acct_uri_parse_validate(candidate: str) -> ParsedUri | None:
     """
     Validate that the provided string is a valid HTTP, HTTPS or ACCT URI.
-    return: string if valid, None otherwise
+    return: ParsedUri if valid, None otherwise
     """
-    parsed = urlparse(candidate)
-    if parsed.scheme in ['http', 'https'] and len(parsed.netloc) > 0:
-        return candidate
-    if parsed.scheme == 'acct':
-        # Don't like this parser
-        if ACCT_REGEX.match(candidate):
-            return candidate
+    parsed = ParsedUri.parse(candidate)
+    if isinstance(parsed,ParsedNonAcctUri):
+        if parsed.scheme in ['http', 'https'] and len(parsed.netloc) > 0:
+            return parsed
+
+    elif isinstance(parsed,ParsedAcctUri):
+        if parsed.user and parsed.host:
+            return parsed
     return None
 
 
-def uri_parse_validate(candidate: str) -> str | None:
+def http_https_acct_uri_validate(candidate: str) -> str | None:
+    parsed = http_https_acct_uri_parse_validate(candidate)
+    if parsed:
+        return parsed.get_uri()
+    return None
+
+
+def uri_parse_validate(candidate: str) -> ParsedUri | None:
     """
     Validate that the provided string is a valid URI.
     return: string if valid, None otherwise
     """
-    parsed = urlparse(candidate)
-    if len(parsed.scheme) > 0 and len(parsed.netloc) > 0:
-        return candidate
+    parsed = ParsedUri.parse(candidate)
+    return parsed
+
+
+def uri_validate(candidate: str) -> str | None:
+    parsed = uri_parse_validate(candidate)
+    if parsed:
+        return parsed.get_uri()
     return None
 
 
@@ -136,7 +281,7 @@ def rfc5646_language_tag_parse_validate(candidate: str) -> str | None:
     return None
 
 
-def hostname_parse_validate(candidate: str) -> str | None:
+def hostname_validate(candidate: str) -> str | None:
     """
     Validate that the provided string is a valid hostname.
     return: string if valid, None otherwise


### PR DESCRIPTION
* Sometimes we want to validate and parse an identifier, and sometimes we only want to validate. Have separate calls for that.
* Make ParsedUri more useful by also using it for acct: URIs; new subclasses; move to utils
* Better invalid-URI checking