### PR TITLE
Added Origin header for conditional CORS headers

### DIFF
--- a/src/feditest/nodedrivers/imp/__init__.py
+++ b/src/feditest/nodedrivers/imp/__init__.py
@@ -22,6 +22,7 @@ from feditest.utils import FEDITEST_VERSION
 
 _HEADERS = {
     "User-Agent": f"feditest/{ FEDITEST_VERSION }",
+    "Origin": "test.example" # to trigger CORS headers in response
 }
 
 class Imp(WebFingerClient):


### PR DESCRIPTION
I did some investigation into why the tests weren't seeing CORS headers from Mastodon given they have configured CORS middleware for the `.well-known/*` route. It turns out that the CORS headers are not sent unless there's an Origin header (which a browser would send). I made a very simple change to add the header. The domain doesn't matter in this case.

Although very strict enforcement of the RFC would require the CORS header even without the "Origin" header, it seems that the existing behavior satisfies the spirit of the RFC requirement -- that browsers can make queries to the WebFinger endpoint.

I don't know what other servers have the same behavior.