### PR TITLE
Count tests that cannot be run because a Node or NodeDriver doesn't implement a method as skipped.

### DIFF
--- a/src/feditest/protocols/__init__.py
+++ b/src/feditest/protocols/__init__.py
@@ -6,6 +6,7 @@ from abc import ABC
 from collections.abc import Callable
 from typing import Any, final
 
+from feditest import SkipTestException
 from feditest.reporting import warning
 
 
@@ -169,7 +170,7 @@ class NodeDriver(ABC):
         return f'"{ self.name }"'
 
 
-class NotImplementedByNodeOrDriverError(RuntimeError):
+class NotImplementedByNodeOrDriverError(SkipTestException):
     pass
 
 

--- a/src/feditest/testruntranscript.py
+++ b/src/feditest/testruntranscript.py
@@ -230,7 +230,7 @@ class TestRunTranscriptSummary:
             self.soft_failures.append(result)
         elif result.type.endswith('DegradeAssertionFailure'):
             self.degrade_failures.append(result)
-        elif result.type.endswith('SkipTestException'):
+        elif result.type.endswith('SkipTestException') or result.type.endswith('NotImplementedByNodeError') or result.type.endswith('NotImplementedByNodeDriverError'):
             self.skips.append(result)
         elif result.type.endswith('AbortTestRunException') or result.type.endswith('AbortTestRunSessionException') or result.type.endswith('AbortTestException'):
             self.interaction_controls.append(result)


### PR DESCRIPTION
Closes #71