### PR TITLE
Fix imp api

### DIFF
--- a/src/feditest/protocols/web/__init__.py
+++ b/src/feditest/protocols/web/__init__.py
@@ -117,6 +117,10 @@ class WebClient(Node):
             self._request = request
 
 
+        def __str__(self):
+            f'Too many redirects: { self._request.uri.get_uri() }'
+
+
     class HttpUnsuccessfulError(RuntimeError):
         """
         Thrown to indicate an unsuccessful HTTP request because DNS could not be resolved, the request
@@ -127,3 +131,33 @@ class WebClient(Node):
             request: the request
             """
             self._request = request
+
+
+        def __str__(self):
+            f'Unsuccessful HTTP request: { self._request.uri.get_uri() }'
+
+
+    class WrongHttpStatusError(RuntimeError):
+        """
+        Raised when an HTTP status was obtained that was wrong for the situation.
+        """
+        def __init__(self, http_request_response_pair: HttpRequestResponsePair):
+            self._http_request_response_pair = http_request_response_pair
+
+
+        def __str__(self):
+            return 'Wrong HTTP status code.' \
+                   + f'\n -> { self._http_request_response_pair.response.http_status }'
+
+
+    class WrongContentTypeError(RuntimeError):
+        """
+        Raised when payload of a content type was received that was wrong for the situation
+        """
+        def __init__(self, http_request_response_pair: HttpRequestResponsePair):
+            self._http_request_response_pair = http_request_response_pair
+
+
+        def __str__(self):
+            return 'Wrong HTTP content type.' \
+                   + f'\n -> "{ self._http_request_response_pair.response.content_type() }"'

--- a/src/feditest/protocols/webfinger/__init__.py
+++ b/src/feditest/protocols/webfinger/__init__.py
@@ -7,7 +7,6 @@ from urllib.parse import quote, urlparse
 
 from feditest.protocols import NotImplementedByNodeError
 from feditest.protocols.web import WebClient, WebServer
-from feditest.protocols.web.traffic import HttpRequestResponsePair
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
 from feditest.utils import http_https_acct_uri_validate
 
@@ -86,7 +85,8 @@ class WebFingerClient(WebClient):
         The resource_uri must be a valid, absolute URI, such as 'acct:foo@bar.com` or
         'https://example.com/aabc' (not escaped).
         rels is an optional list of 'rel' query parameters
-        Return the result of the query
+        Return the result of the query. This should returns WebFingerQueryResponse in as many cases
+        as possible, but the WebFingerQueryResponse may indicate errors.
         """
         raise NotImplementedByNodeError(self, WebFingerClient.perform_webfinger_query)
 
@@ -134,13 +134,3 @@ class WebFingerClient(WebClient):
         """
         def __init__(self, resource_uri: str):
             self.resource_uri = resource_uri
-
-
-    class WebfingerQueryFailedError(RuntimeError):
-        """
-        Raised when no JRD could be obtained (e.g. got 404)
-        """
-        def __init__(self, resource_uri: str, http_request_response_pair: HttpRequestResponsePair | None, msg: str | None = None ):
-            super().__init__(msg)
-            self.resource_uri = resource_uri
-            self.http_request_response_pair = http_request_response_pair

--- a/src/feditest/protocols/webfinger/traffic.py
+++ b/src/feditest/protocols/webfinger/traffic.py
@@ -28,7 +28,16 @@ class ClaimedJrd:
         """
         Represents a problem during JRD parsing, such as syntax error.
         """
-        pass # pylint: disable=unnecessary-pass
+        def __init__(self, jrd: 'ClaimedJrd', msg: str):
+            self._jrd = jrd
+            self._msg = msg
+
+
+        def __str__(self):
+            if self._msg:
+                return f'{ self.__class__.__name__ }: { self._msg }'
+            else:
+                return self.__class__.__name__
 
 
     class InvalidTypeError(JrdError):
@@ -98,6 +107,13 @@ class ClaimedJrd:
 
     def as_json_string(self) -> Any:
         return json.dumps(self._json)
+
+
+    @staticmethod
+    def create_and_validate(value: str) -> 'ClaimedJrd':
+        ret = ClaimedJrd(value) # may raise JSONDecodeError
+        ret.validate()          # may raise any of the errors defined here
+        return ret
 
 
     @staticmethod
@@ -244,122 +260,119 @@ working-copy-of"""
 
     def validate(self) -> None: # pylint: disable=too-many-branches,too-many-statements
         """
-        Validate the correctness of the JRD. Throw Exceptions if it is not valid.
+        Validate the correctness of the JRD. Throws a single Exceptions if it is not valid. This Exception
+        may be an ExceptionGroup in case there is more than one error.
         """
+        excs : list[Exception] = []
         if not isinstance(self._json, dict):
-            raise ClaimedJrd.InvalidTypeError(self, 'Must be a JSON object')
+            raise ClaimedJrd.InvalidTypeError(self, 'Must be a JSON object') # can't continue otherwise
 
         for key in self._json:
             if key not in self.VALID_JRD_KEYS:
-                raise ClaimedJrd.JrdError(self, f"Invalid key: {key}")
+                excs.append(ClaimedJrd.JrdError(self, f"Invalid key: {key}"))
 
         if 'subject' in self._json:
             # is optional
 
             if not isinstance(self._json['subject'], str):
-                raise ClaimedJrd.InvalidTypeError(self, 'Member subject must be a string')
-
-            if http_https_acct_uri_parse_validate(self._json['subject']) is None:
-                raise ClaimedJrd.InvalidUriError(self, 'Member subject must be an absolute URI')
+                excs.append(ClaimedJrd.InvalidTypeError(self, 'Member subject must be a string'))
+            elif http_https_acct_uri_parse_validate(self._json['subject']) is None:
+                excs.append(ClaimedJrd.InvalidUriError(self, 'Member subject must be an absolute URI'))
 
 
         if 'aliases' in self._json:
             # is optional
 
             if not isinstance(self._json['aliases'], list):
-                raise ClaimedJrd.InvalidTypeError(self, 'Member aliases must be a JSON array')
-
-            for alias in self._json['aliases'] :
-                if not isinstance(alias, str):
-                    raise ClaimedJrd.InvalidTypeError(self, 'Members of the aliases array must be strings')
-
-                if http_https_acct_uri_parse_validate(alias) is None:
-                    raise ClaimedJrd.InvalidUriError(self, 'Members of aliases array must be absolute URIs')
+                excs.append(ClaimedJrd.InvalidTypeError(self, 'Member aliases must be a JSON array'))
+            else:
+                for alias in self._json['aliases'] :
+                    if not isinstance(alias, str):
+                        excs.append(ClaimedJrd.InvalidTypeError(self, 'Members of the aliases array must be strings'))
+                    elif http_https_acct_uri_parse_validate(alias) is None:
+                        excs.append(ClaimedJrd.InvalidUriError(self, 'Members of aliases array must be absolute URIs'))
 
         if 'properties' in self._json:
             # is optional
 
             if not isinstance(self._json['properties'], dict):
-                raise ClaimedJrd.InvalidTypeError(self, 'Member properties must be a JSON object')
-
-            for key, value in self._json['properties'].items():
-                if not isinstance(key, str):
-                    raise ClaimedJrd.InvalidTypeError(self, 'Names in the properties object must be strings')
-
-                if http_https_acct_uri_parse_validate(key) is None:
-                    raise ClaimedJrd.InvalidUriError(self, 'Names in the properties object must be absolute URIs')
-
-                if value is not None and not isinstance(value, str):
-                    raise ClaimedJrd.InvalidTypeError(self, 'Values in the properties object must be strings or null')
+                excs.append(ClaimedJrd.InvalidTypeError(self, 'Member properties must be a JSON object'))
+            else:
+                for key, value in self._json['properties'].items():
+                    if not isinstance(key, str):
+                        excs.append(ClaimedJrd.InvalidTypeError(self, 'Names in the properties object must be strings'))
+                    elif http_https_acct_uri_parse_validate(key) is None:
+                        excs.append(ClaimedJrd.InvalidUriError(self, 'Names in the properties object must be absolute URIs'))
+                    elif value is not None and not isinstance(value, str):
+                        excs.append(ClaimedJrd.InvalidTypeError(self, 'Values in the properties object must be strings or null'))
 
         if 'links' in self._json:
             # is optional
 
             if not isinstance(self._json['links'], list):
-                raise ClaimedJrd.InvalidTypeError(self, 'Member links must be a JSON array')
+                excs.append(ClaimedJrd.InvalidTypeError(self, 'Member links must be a JSON array'))
+            else:
+                for link in self._json['links']:
+                    if not isinstance(link, dict):
+                        excs.append(ClaimedJrd.InvalidTypeError(self, 'Members of the links array must be JSON objects'))
+                    elif 'rel' not in link:
+                        excs.append(ClaimedJrd.MissingMemberError(self, 'All members of the links array must have a rel property'))
+                    elif not isinstance(link['rel'], str):
+                        excs.append(ClaimedJrd.InvalidTypeError(self, 'Values for the rel member in the links array must be strings'))
+                    elif http_https_acct_uri_parse_validate(link['rel']) is None and not ClaimedJrd.is_registered_relation_type(link['rel']):
+                        excs.append(ClaimedJrd.InvalidRelError(self, f'All rel entries in the links array must be a URI or a registered relation type: {link["rel"]}'))
 
-            for link in self._json['links']:
-                if not isinstance(link, dict):
-                    raise ClaimedJrd.InvalidTypeError(self, 'Members of the links array must be JSON objects')
+                    if 'type' in link:
+                        # is optional
 
-                if 'rel' not in link:
-                    raise ClaimedJrd.MissingMemberError(self, 'All members of the links array must have a rel property')
+                        if not isinstance(link['type'], str):
+                            excs.append(ClaimedJrd.InvalidTypeError(self, 'Values for the type member in the links array must be strings'))
+                        elif not ClaimedJrd.is_valid_media_type(link['type']):
+                            excs.append(ClaimedJrd.InvalidMediaTypeError(self, f'Values for the type member in the links array must be valid media types: { link["type"] }'))
 
-                if not isinstance(link['rel'], str):
-                    raise ClaimedJrd.InvalidTypeError(self, 'Values for the rel member in the links array must be strings')
+                    if 'href' in link:
+                        # is optional
 
-                if http_https_acct_uri_parse_validate(link['rel']) is None and not ClaimedJrd.is_registered_relation_type(link['rel']):
-                    raise ClaimedJrd.InvalidRelError(self, f'All rel entries in the links array must be a URI or a registered relation type: {link["rel"]}')
+                        if not isinstance(link['href'], str):
+                            excs.append(ClaimedJrd.InvalidTypeError(self, 'Values for the type member in the links array must be strings'))
+                        elif uri_parse_validate(link['href']) is None:
+                            excs.append( ClaimedJrd.InvalidUriError(self, 'Values for the href member in the links array must be URIs'))
 
-                if 'type' in link:
-                    # is optional
+                    if 'titles' in link:
+                        # is optional
 
-                    if not isinstance(link['type'], str):
-                        raise ClaimedJrd.InvalidTypeError(self, 'Values for the type member in the links array must be strings')
+                        if not isinstance(link['titles'], dict):
+                            excs.append(ClaimedJrd.InvalidTypeError(self, 'Values for the titles member in a links array mbmber must be JSON objects'))
+                        else:
+                            for key, value in link['titles']:
+                                if not isinstance(key,str):
+                                    excs.append(ClaimedJrd.InvalidTypeError(self, 'Names in the titles object in a links array member must be strings'))
+                                elif key != 'und' and rfc5646_language_tag_parse_validate(key) is None:
+                                    excs.append(ClaimedJrd.InvalidLanguageTagError(self, f'Names in the titles object in a links array member must be valid language tags or "und": { key }'))
 
-                    if not ClaimedJrd.is_valid_media_type(link['type']):
-                        raise ClaimedJrd.InvalidMediaTypeError(self, f'Values for the type member in the links array must be valid media types: { link["type"] }')
+                                if not value or not isinstance(value, str):
+                                    excs.append(ClaimedJrd.InvalidValueError(self, 'Values in the titles objects in a links array member must be non-null strings'))
 
-                if 'href' in link:
-                    # is optional
+                    if 'properties' in link:
+                        # is optional
 
-                    if not isinstance(link['href'], str):
-                        raise ClaimedJrd.InvalidTypeError(self, 'Values for the type member in the links array must be strings')
+                        if not isinstance(link['properties'], dict):
+                            excs.append(ClaimedJrd.InvalidTypeError(self, 'Member properties in a links array member must be a JSON object'))
+                        else:
+                            for key, value in link['properties']:
+                                if not isinstance(key, str):
+                                    excs.append(ClaimedJrd.InvalidTypeError(self, 'Names in the properties object in a links array member must be strings'))
+                                elif http_https_acct_uri_parse_validate(key) is None:
+                                    excs.append(ClaimedJrd.InvalidUriError(self, 'Names in the properties object in a links array member must be absolute URIs'))
 
-                    if uri_parse_validate(link['href']) is None:
-                        raise ClaimedJrd.InvalidUriError(self, 'Values for the href member in the links array must be URIs')
+                                if value is not None and not isinstance(value, str):
+                                    excs.append(ClaimedJrd.InvalidTypeError(self, 'Values in the properties object in a links array member must be strings or null'))
 
-                if 'titles' in link:
-                    # is optional
-
-                    if not isinstance(link['titles'], dict):
-                        raise ClaimedJrd.InvalidTypeError(self, 'Values for the titles member in a links array mbmber must be JSON objects')
-
-                    for key, value in link['titles']:
-                        if not isinstance(key,str):
-                            raise ClaimedJrd.InvalidTypeError(self, 'Names in the titles object in a links array member must be strings')
-
-                        if key != 'und' and rfc5646_language_tag_parse_validate(key) is None:
-                            raise ClaimedJrd.InvalidLanguageTagError(self, f'Names in the titles object in a links array member must be valid language tags or "und": { key }')
-
-                        if not value or not isinstance(value, str):
-                            raise ClaimedJrd.InvalidValueError(self, 'Values in the titles objects in a links array member must be non-null strings')
-
-                if 'properties' in link:
-                    # is optional
-
-                    if not isinstance(link['properties'], dict):
-                        raise ClaimedJrd.InvalidTypeError(self, 'Member properties in a links array member must be a JSON object')
-
-                    for key, value in link['properties']:
-                        if not isinstance(key, str):
-                            raise ClaimedJrd.InvalidTypeError(self, 'Names in the properties object in a links array member must be strings')
-
-                        if http_https_acct_uri_parse_validate(key) is None:
-                            raise ClaimedJrd.InvalidUriError(self, 'Names in the properties object in a links array member must be absolute URIs')
-
-                        if value is not None and not isinstance(value, str):
-                            raise ClaimedJrd.InvalidTypeError(self, 'Values in the properties object in a links array member must be strings or null')
+        if excs:
+            if len(excs) == 1:
+                raise excs[0]
+            else:
+                raise ExceptionGroup('JRD has multiple errors', excs)
 
 
     def is_valid_link_subset(self, jrd_with_superset : 'ClaimedJrd', rels: list[str] | None = None) -> bool:
@@ -448,7 +461,15 @@ working-copy-of"""
         return True
 
 
+    def __str__(self):
+        """
+        For error messages.
+        """
+        return json.dumps(self._json)
+
+
 @dataclass
 class WebFingerQueryResponse:
     http_request_response_pair: HttpRequestResponsePair
-    jrd : ClaimedJrd | None
+    jrd : ClaimedJrd | None # This may be an invalid jrd
+    exc : Exception | None #

--- a/src/feditest/protocols/webfinger/utils.py
+++ b/src/feditest/protocols/webfinger/utils.py
@@ -2,13 +2,58 @@
 Webfinger testing utils
 """
 
+from typing import Any, Type
+
 from multidict import MultiDict
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
 
-from feditest.protocols.webfinger.traffic import ClaimedJrd
+from feditest.protocols.webfinger.traffic import ClaimedJrd, WebFingerQueryResponse
 
-class LinkSubsetOrEqualsToMatcher(BaseMatcher):
+class RecursiveEqualToMatcher(BaseMatcher):
+    """
+    Custom matcher: recursively match two objects
+    """
+    def __init__(self, other: Any):
+        self._other = other
+
+
+    def _matches(self, here: Any) -> bool:
+        return self._equals(here, self._other)
+
+
+    def _equals(self, a: Any, b: Any):
+        if a is None:
+            return b is None
+        if b is None:
+            return False
+        if type(a) is not type(b):
+            return False
+        if isinstance(a, (int, float, str, bool)):
+            return a == b
+        if isinstance(a, (list, tuple, set)):
+            if len(a) != len(b):
+                return False
+            return all(self._equals(aa, bb) for aa, bb in zip(a, b))
+        if isinstance(a, dict):
+            if len(a) != len(b):
+                return False
+            for key in a:
+                if key not in b:
+                    return False
+                if not self._equals(a[key], b[key]):
+                    return False
+            return True
+        if hasattr(a, '__dict__') and hasattr(b, '__dict__'):
+            return self._equals(a.__dict__, b.__dict__)
+        return False # not sure what else it can be
+
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text(f'Objects must be of the same type and recursive structure: { self._other }')
+
+
+class LinkSubsetOrEqualToMatcher(BaseMatcher):
     """
     Custom matcher: decide whether this JRD is the same as the provided JRD,
     or is the same with only a subset of the link elements.
@@ -28,7 +73,10 @@ class LinkSubsetOrEqualsToMatcher(BaseMatcher):
 
 
     def describe_to(self, description: Description) -> None:
-        description.append_text('Links must be the same or a subset')
+        description.append_text('Links must be the same or a subset.')
+        description.append_text(f'JRD: { self._jrd_with_superset }')
+        if self._rels:
+            description.append_text(f'rels: { ", ".join(self._rels) }')
 
 
 class MultiDictHasKeyMatcher(BaseMatcher):
@@ -48,9 +96,67 @@ class MultiDictHasKeyMatcher(BaseMatcher):
         description.append_text(f'MultiDict has key: { self._key }')
 
 
-def link_subset_or_equal_to(arg: ClaimedJrd) -> LinkSubsetOrEqualsToMatcher :
-    return LinkSubsetOrEqualsToMatcher(arg)
+class NoneExceptMatcher(BaseMatcher):
+    """
+    Custom matcher: decode whether an Exception (which may be an ExceptionGroup) contains
+    any Exception other than the provided allowed exceptions.
+    """
+    def __init__(self, allowed_excs: list[Type[Exception]]):
+        self._allowed_excs = allowed_excs
+
+
+    def _matches(self, candidate: Exception | None ) -> bool:
+        if candidate is None:
+            return True
+        if isinstance(candidate, ExceptionGroup):
+            for cand in candidate.exceptions:
+                found = False
+                for allowed in self._allowed_excs:
+                    if isinstance(cand, allowed):
+                        found = True
+                if not found:
+                    return False
+            return True
+
+        for allowed in self._allowed_excs:
+            if isinstance(candidate, allowed):
+                return True
+        return False
+
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text(f'No exception other than: { ",".join( [ x.__name__ for x in self._allowed_excs ] ) }')
+
+
+def recursive_equal_to(arg: object) -> RecursiveEqualToMatcher :
+    return RecursiveEqualToMatcher(arg)
+
+
+def link_subset_or_equal_to(arg: ClaimedJrd) -> LinkSubsetOrEqualToMatcher :
+    return LinkSubsetOrEqualToMatcher(arg)
 
 
 def multi_dict_has_key(arg: str) -> MultiDictHasKeyMatcher :
     return MultiDictHasKeyMatcher(arg)
+
+
+def none_except(*allowed_excs : Type[Exception]) -> NoneExceptMatcher :
+    return NoneExceptMatcher(list(allowed_excs))
+
+
+def wf_error(response: WebFingerQueryResponse) -> str:
+    """
+    Construct an error message
+    """
+    if not response.exc:
+        return 'ok'
+    msg = str(response.exc).split('\n')[0]
+    msg += f'\nAccessed URI: "{ response.http_request_response_pair.request.uri.get_uri() }".'
+
+    if isinstance(response.exc, ExceptionGroup):
+        for i, exc in enumerate(response.exc.exceptions):
+            msg += f'\n{ i }: { exc }'
+    else:
+        msg += '\n'.join(str(response.exc).split('\n')[1:])
+
+    return msg


### PR DESCRIPTION
* Changing the WebFingerClient API slightly: Instead of throwing an Exception the first time the an implementing class doesn't like something, don't throw but return a set of all problems. This is probably what a good library would do, so that the code invoking the library could report errors nicely. It allows us to filter out certain errors when running certain tests, so that the errors reported in a given test actually match what the test is trying to test.

* Better and more consistent error reporting

* Fix incorrect ClaimedJrd recursive comparison

* Fix the Imp API to match the WebFingerClient API (has consequences for the actual tests)