### PR TITLE
Added multifile report generation and placeholder templates.

### DIFF
--- a/src/feditest/cli/commands/convert_transcript.py
+++ b/src/feditest/cli/commands/convert_transcript.py
@@ -8,6 +8,7 @@ from feditest.reporting import warning
 from feditest.testruntranscript import (
     HtmlTestRunTranscriptSerializer,
     JsonTestRunTranscriptSerializer,
+    MultifileRunTranscriptSerializer,
     SummaryTestRunTranscriptSerializer,
     TapTestRunTranscriptSerializer,
     TestRunTranscript,
@@ -15,6 +16,7 @@ from feditest.testruntranscript import (
 )
 from feditest.utils import FEDITEST_VERSION
 
+SINGLE_FILE_DEFAULT_TEMPLATE = 'testrun-report-testmatrix-standalone.jinja2'
 
 def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
     """
@@ -42,6 +44,17 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
         serializer = SummaryTestRunTranscriptSerializer(transcript)
         serializer.write(args.json)
 
+    if isinstance(args.multifile, str):
+        template = args.template
+        if template == SINGLE_FILE_DEFAULT_TEMPLATE:
+            template = "multifile"
+        serializer = MultifileRunTranscriptSerializer(args.multifile, template)
+        try:
+            serializer.write(transcript)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+
     return 0
 
 
@@ -58,9 +71,12 @@ def add_sub_parser(parent_parser: _SubParsersAction, cmd_name: str) -> None:
     html_group = parser.add_argument_group('html', 'HTML options')
     html_group.add_argument('--html', nargs="?", const=True, default=False,
                         help="Write results in HTML format to stdout, or to the provided file (if given).")
-    html_group.add_argument('--template', default='testrun-report-testmatrix-standalone.jinja2',
+    html_group.add_argument('--template', default=SINGLE_FILE_DEFAULT_TEMPLATE,
                         help="When specifying --html, use this HTML template (jinja2 format).")
     parser.add_argument('--json', nargs="?", const=True, default=False,
                         help="Write results in JSON format to stdout, or to the provided file (if given).")
     parser.add_argument('--summary', nargs="?", const=True, default=False,
                         help="Write summary to stdout, or to the provided file (if given). This is the default if no other output option is given")
+    parser.add_argument("--multifile", 
+        help="""Write results to a directory of files. A matrix and a file per session. 
+        The template argument refers to to a directory (path) of template directories""")

--- a/src/feditest/templates/multifile/partials/test_matrix/table.jinja2
+++ b/src/feditest/templates/multifile/partials/test_matrix/table.jinja2
@@ -1,0 +1,56 @@
+{% macro column_headings() %}
+                    <tr>
+                    <th>Test (alphabetical order)</th>
+{%- for run_session in run.sessions %}
+{%-     set plan_session = run.plan.sessions[run_session.plan_session_index] %}
+{%-     set constellation = plan_session.constellation %}
+                    <th>
+                        <div class="title">
+{%-     if session_links -%}
+                            <a href="{{ session_file_path(plan_session) }}">
+{%-     endif -%}
+                            {{ constellation.name or "Unnamed" }}
+{%-     if session_links -%}
+                            </a>
+{%-     endif -%}
+                        </div>
+                    </th>
+{%- endfor %}
+                </tr>
+{% endmacro %}
+
+    <div class="feditest tests">
+        <table class="tests">
+            <colgroup>
+                <col>
+{%- for run_session in run.sessions %}
+                <col class="session">
+{%- endfor %}
+            </colgroup>
+            <thead>
+                {{ column_headings() }}
+            </thead>
+            <tbody>
+{%- for _, test_meta in sorted(run.test_meta.items()) %}
+                <tr>
+                    <td class="namedesc">
+                        <span class="name">{{ permit_line_breaks_in_identifier(test_meta.name) }}</span>
+{%-     if test_meta.description %}
+                        <span class="description">{{ test_meta.description }}</span>
+{%-     endif %}
+                    </td>
+{%-     for run_session in run.sessions %}
+                    <td class="status">
+{%-         for result in get_results_for(run, run_session, test_meta) %}
+{%              include "testresult-brief.jinja2" %}
+{%-         endfor %}
+                    </td>
+{%-     endfor %}
+                </tr>
+{%- endfor %}
+            </tbody>
+            <tfoot>
+                {{ column_headings() }}
+            </thead>
+        </table>
+    </div>

--- a/src/feditest/templates/multifile/partials/test_session/metadata.jinja2
+++ b/src/feditest/templates/multifile/partials/test_session/metadata.jinja2
@@ -1,0 +1,29 @@
+<div class="feditest metadata">
+{%- set started = run_session.started %}
+{%- set ended = run_session.ended %}
+{%- set duration = ended - started %}
+    <table>
+        <tbody>
+            <tr>
+                <th>Started</th>
+                <td>{{ format_timestamp(started) }}</td>
+            </tr>
+            <tr>
+                <th>Ended</th>
+                <td>{{ format_timestamp(ended) }} (total: {{ format_duration(duration) }})</td>
+            </tr>
+{%- for key in ['username', 'hostname', 'platform'] -%}
+{%-     if getattr(run,key) %}
+            <tr>
+                <th>{{ key.capitalize() }}</th>
+                <td>{{ getattr(run, key) }}</td>
+            </tr>
+{%-     endif %}
+{%- endfor %}
+            <tr>
+                <th>Feditest&nbsp;version</th>
+                <td>{{ getattr(run, 'feditest_version') }}</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/src/feditest/templates/multifile/partials/test_session/results.jinja2
+++ b/src/feditest/templates/multifile/partials/test_session/results.jinja2
@@ -1,0 +1,54 @@
+{%-     set plan_session = run.plan.sessions[run_session.plan_session_index] %}
+{%-     set constellation = plan_session.constellation %}
+   <div class="feditest module results">
+        <h2>Constellation</h2>
+                    <dl class="roles"">
+{%-     for role_name, role in constellation.roles.items() %}
+                        <dt>{{ role_name }}</dt>
+                        
+                        <dd>{% if role.parameters.app %}
+                            {{ role.parameters.app}}
+                            {% else %}
+                            <code>{{ role.nodedriver }}</code>
+                            {% endif %}
+                        </dd> 
+{%-     endfor %}
+                    </dl>
+        <h2>Test Results</h2>
+            <div class="feditest tests">
+                <div class="session">
+{%-     for test_index, run_test in enumerate(run_session.run_tests) %}
+{%-         set plan_test_spec = plan_session.tests[run_test.plan_test_index] %}
+{%-         set test_meta = run.test_meta[plan_test_spec.name] %}
+                    <div class="test">
+                        <h4><span class="prefix">Test:</span> {{ test_meta.name }}</h4>
+{%-         if test_meta.description %}
+                            <div class="description">{{ test_meta.description}}</div>
+{%-         endif %}
+                        <p class="when">Started {{ format_timestamp(run_test.started) }}, ended {{ format_timestamp(run_test.ended) }}</p>
+{%-         with result=run_test.worst_result %}
+{%-             include "testresult-full.jinja2" %}
+{%-         endwith %}
+{%-         for test_step_index, run_step in enumerate(run_test.run_steps or []) %}
+                        <div class="step">
+{%              set test_step_meta = test_meta.steps[run_step.plan_step_index] %}
+                            <h5><span class="prefix">Test step:</span> {{ test_step_meta.name }}</h5>
+{%-             if test_step_meta.description %}
+                                <div class="description">{{ test_step_meta.description}}</div>
+{%-             endif %}
+                            <p class="when">Started {{ format_timestamp(run_step.started) }}, ended {{ format_timestamp(run_step.ended) }}</p>
+
+{%-             with result=run_step.result, idmod='step' %}
+{%-                 include "testresult-full.jinja2" %}
+{%-             endwith %}
+                        </div>
+{%-         endfor %}
+                    </div>
+{%-     endfor %}
+                </div>
+            </div>
+    </div>
+    {# <div class="feditest module metadata">
+        <h2>Test Run Metadata</h2>
+{%  include "testrun-transcript-metadata.jinja2" %}
+    </div> #}

--- a/src/feditest/templates/multifile/partials/test_session/title.jinja2
+++ b/src/feditest/templates/multifile/partials/test_session/title.jinja2
@@ -1,0 +1,5 @@
+{% set plan_session = run.plan.sessions[run_session.plan_session_index] %}
+<header class="feditest title" style="text-align: center">
+  <h1><span class="prefix"><a href="https://feditest.org/">Feditest</a>:</span> {{ plan_session.name }}</h1>
+  <p class="id">{{ run.id }} [<a href="../">Test Matrix</a>] </p>
+</header>

--- a/src/feditest/templates/multifile/static/css/common.css
+++ b/src/feditest/templates/multifile/static/css/common.css
@@ -1,0 +1,178 @@
+:root:not([data-theme="dark"]), [data-theme="light"] {
+	--feditest-background-color: #f8f8f8;
+	--feditest-h4-background-color: #e8e8e8;
+    --feditest-color-status: inherit;
+    --feditest-color-status-passed: #BBF5CA;
+    --feditest-color-status-hard: #F5B0A7;
+    --feditest-color-status-soft: #F5D4A4;
+    --feditest-color-status-degrade: #EDF593;
+    --feditest-color-status-skip: inherit;
+    --feditest-color-status-error: #F58171;
+}
+
+@media only screen and (prefers-color-scheme: dark) {
+	:root:not([data-theme]) {
+		--feditest-background-color: #000;
+		--feditest-h4-background-color: #242c38;
+        --feditest-color-status: #000;
+        --feditest-color-status-passed: #BBF5CA;
+        --feditest-color-status-hard: #F5B0A7;
+        --feditest-color-status-soft: #F5D4A4;
+        --feditest-color-status-degrade: #EDF593;
+        --feditest-color-status-skip: inherit;
+        --feditest-color-status-error: #F58171;
+    }
+}
+
+:root {
+    --pico-font-size: 100%;
+}
+
+body {
+    padding: 2rem;
+	background: var(--feditest-background-color);
+}
+
+footer {
+    font-size: smaller;
+}
+
+div.feditest.title {
+    text-align: center;
+}
+div.feditest span.prefix,
+div.feditest span.prefix a {
+		color: var(--pico-muted-color);
+}
+
+div.feditest.title .id::before {
+	content: "TestRun ID: "
+}
+
+div.feditest.module {
+    background: var(--pico-background-color);
+    border-radius: 5px;
+    border: 1px solid var(--pico-table-border-color);
+    margin: 0 0 2rem 0;
+    padding: 2rem;
+}
+
+div.feditest.module.summary {
+    box-shadow: 0px 0px 5px var(--pico-table-border-color);
+}
+
+div.feditest.module.results {
+    box-shadow: 0px 0px 5px var(--pico-table-border-color);
+}
+
+div.feditest.session {
+    margin-bottom: 2rem;
+}
+
+div.feditest.session > h3 {
+    font-weight: bold;
+}
+
+div.feditest.session > h3::before {
+    content: "Session: ";
+	color: var(--pico-muted-color);
+}
+
+.feditest h4 {
+    background: var(--feditest-h4-background-color);
+}
+
+.feditest div.session + div.session {
+	padding-top: 2em;
+	margin-top: 2em;
+	border-top: 1px solid var(--pico-table-border-color);
+}
+
+.feditest div.constellation > h4::before {
+    content: "Constellation: ";
+	color: var(--pico-muted-color);
+}
+
+.feditest div.roles {
+    display: flex;
+    gap: 1rem;
+    margin-left: 1rem;
+}
+
+.feditest div.role {
+    width: 30rem;
+    border: 1px solid;
+    padding: 1rem;
+    border-color: var(--pico-table-border-color);
+}
+
+.feditest div.role > div.name {
+    font-weight: bold;
+
+}
+
+.feditest div.role > div.name::before {
+    content: "Role: ";
+}
+
+.feditest div.role > div.driver::before {
+    content: "Node Driver: ";
+}
+
+.feditest div.role > div.app::before {
+    content: "App: ";
+}
+
+.feditest div.role > div.appversion::before {
+    content: "App version: ";
+}
+
+.feditest div.status {
+    color: var(--feditest-color-status);
+    padding: .5rem;
+}
+
+.feditest .status.passed {
+    background: var(--feditest-color-status-passed);
+}
+
+.feditest .status.hard {
+    background: var(--feditest-color-status-hard);
+}
+
+.feditest .status.soft {
+    background: var(--feditest-color-status-soft);
+}
+
+.feditest .status.degrade {
+    background: var(--feditest-color-status-degrade);
+}
+
+.feditest .status.skip {
+    background: var(--feditest-color-status-skip);
+}
+.feditest .status.error {
+    background: var(--feditest-color-status-error);
+}
+
+.feditest .status input {
+    display: none;
+}
+
+.feditest pre.stacktrace {
+    display: none;
+    padding: 1rem;
+}
+
+.feditest input:checked + pre.stacktrace {
+    display: block;
+}
+
+.feditest .status label {
+    color: inherit;
+}
+
+.feditest .status label::after {
+    content: " ▼";
+    color: inherit;
+}

--- a/src/feditest/templates/multifile/static/css/feditest.css
+++ b/src/feditest/templates/multifile/static/css/feditest.css
@@ -1,0 +1,99 @@
+/* This was previously embedded in some of the templates */
+
+div.feditest.tests {
+    overflow: auto;
+    position: relative;
+}
+
+div.feditest.tests div.roles dd {
+    font-weight: normal;
+}
+
+div.feditest.tests .namedesc>span {
+    display: block;
+}
+
+div.feditest.tests .namedesc>span.name {
+    font-weight: bold;
+}
+
+.feditest .role>table.parameters {
+    font-size: 0.8rem;
+}
+
+.feditest dl.roles {
+    display: grid;
+    grid-template-columns: auto auto;
+    width: fit-content;
+    column-gap: 8px;
+}
+
+.feditest dl.roles dt::after {
+    content: ": ";
+}
+
+.feditest dl.roles dd {
+    margin-left: 0;
+    font-weight: normal;
+}
+
+.feditest table.tests {
+    overflow: scroll;
+    border-collapse: collapse;
+}
+
+.feditest table.tests td:first-child,
+.feditest table.tests th:first-child {
+    position: sticky;
+    left: 0;
+}
+
+.feditest table.tests col.session {
+    border: 2px solid var(--pico-contast);
+}
+
+.feditest div.status {
+    max-width: 120px;
+    max-height: 150px;
+    overflow: auto;
+}
+
+.feditest .session .test {
+    margin-bottom: 2rem;;
+}
+
+div.feditest.module.summary {
+    box-shadow: none;
+}
+
+div.feditest.module.results {
+    box-shadow: none;
+}
+
+div.feditest.module {
+    border: none;
+}
+
+table.feditest.summary {
+    width: 20rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    table.feditest.summary td.status {
+        color: black;
+    }
+}
+
+nav.matrix {
+    display: block;
+    text-align: center;
+}
+
+nav.matrix ul {
+    display: block;
+    font-size: 1.4rem;
+}
+
+table.tests tfoot th:first-of-type {
+    visibility: hidden;
+}

--- a/src/feditest/templates/multifile/test_matrix.jinja2
+++ b/src/feditest/templates/multifile/test_matrix.jinja2
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Feditest Test Report</title>
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+        >
+        <link rel="stylesheet" href="css/common.css">
+        <link rel="stylesheet" href="css/feditest.css">
+    </head>
+    <body>
+{%  include "testrun-transcript-title.jinja2" %}
+        <nav class="matrix">
+            <ul>
+                <li><a href="#summary">Summary</a></li>
+                <li><a href="#results">Results</a></li>
+                <li><a href="#metadata">Metadata</a></li>
+            </ul>
+        </nav>
+        <div id="summary" class="feditest module summary">
+            <h2>Test Run Summary</h2>
+{%  include "testrun-transcript-summary.jinja2" %}
+        </div>
+        <div id="results" class="feditest module results">
+{%  with session_links=true %}
+            <h2>Test Results</h2>
+{%      include "partials/test_matrix/table.jinja2" %}
+{%  endwith %}
+        </div>
+        <div id="metadata" class="feditest module metadata">
+            <h2>Test Run Metadata</h2>
+{%  include "testrun-transcript-metadata.jinja2" %}
+        </div>
+{%   include "standalone-report-footer.jinja2" %}
+    </body>
+</html>

--- a/src/feditest/templates/multifile/test_session.jinja2
+++ b/src/feditest/templates/multifile/test_session.jinja2
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% set plan_session = run.plan.sessions[run_session.plan_session_index] %}
+        <title>{{ plan_session.name }} | Feditest</title>
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+        >
+        <!-- The page will be in sessions/(session).html -->
+        <link rel="stylesheet" href="../css/common.css">
+        <link rel="stylesheet" href="../css/feditest.css">
+    </head>
+    <body>
+{%  include "partials/test_session/title.jinja2" %}
+        <nav class="matrix">
+            <ul>
+                <li><a href="#summary">Summary</a></li>
+                <li><a href="#results">Results</a></li>
+                <li><a href="#metadata">Metadata</a></li>
+            </ul>
+        </nav>
+        <div id="summary" class="feditest module summary">
+            <h2>Test Run Summary</h2>
+{%  include "testrun-transcript-summary.jinja2" %}
+        </div>
+        <div id="results" class="feditest module results">
+{%  include "partials/test_session/results.jinja2" %}
+        </div>
+        <div id="metadata" class="feditest module metadata">
+            <h2>Test Run Metadata</h2>
+{%  include "partials/test_session/metadata.jinja2" %}
+        </div>
+{%   include "standalone-report-footer.jinja2" %}
+    </body>
+</html>

--- a/src/feditest/testplan.py
+++ b/src/feditest/testplan.py
@@ -35,10 +35,6 @@ class TestPlanConstellationNode(msgspec.Struct):
         return msgspec.convert(testplanconstellationnode_json, type=TestPlanConstellationNode)
 
 
-    def __str__(self):
-        return self.name
-
-
     def parameter(self, name: str) -> Any | None:
         if self.parameters:
             return self.parameters.get(name)


### PR DESCRIPTION
(Documented in the code...)

    Generates the Feditest reports into a test matrix and a linked, separate
    file per session. It uses a template path so variants of reports can be generated
    while sharing common templates. The file_ext can be specified to support generating
    other formats like MarkDown.

    The generation uses two primary templates. The `test_matrix.jinja2` template is used for
    the matrix generation and 'test_session.jinja2' is used for session file generation.

    Any files in a directory called "static" in a template folder will be copied verbatim
    to the output directory (useful for CSS, etc.). If a file exists in the static folder of more
    than one directory in the template path, earlier path entries will overwrite later ones.

The current templates are placeholders. I think it's close to what we need, but I didn't try to complete it because I know you'll want to make changes. The current `multifile` directory is basically the standalone report. However, we could organize it as something like: `multifile-common`, `multifile-standalone`, and `multifile-hugo` and run the report generator with an argument like `--template multifile-hugo,multifile-common` to use the shared common templates with overrides for the hugo report generation (in this example).

I added a few features to the reports that I had been requesting. The headings are now duplicated at the bottom of the test matrix table so that context isn't lost when horizontally scrolling the results. Some of the block elements were sized at 100% width, which made them more difficult to read on a large monitor. I modified a few of those to "fit to content" (with added spacing, where needed). I removed the "Session n:" prefix from the session detail pages because it didn't seem to serve a purpose. The per-session file names use the plan session name instead of "session-n.html". It seems like that naming would make it easier to copy or locate a specific session's report from the directory, if needed.

Related to #173
