### PR TITLE
Change/fix the default multifile template path for the placeholder templates.

### DIFF
--- a/src/feditest/cli/commands/convert_transcript.py
+++ b/src/feditest/cli/commands/convert_transcript.py
@@ -47,7 +47,7 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
     if isinstance(args.multifile, str):
         template = args.template
         if template == SINGLE_FILE_DEFAULT_TEMPLATE:
-            template = "multifile"
+            template = "multifile,."
         serializer = MultifileRunTranscriptSerializer(args.multifile, template)
         try:
             serializer.write(transcript)

--- a/src/feditest/testruntranscript.py
+++ b/src/feditest/testruntranscript.py
@@ -557,12 +557,11 @@ class MultifileRunTranscriptSerializer:
     def __init__(
         self,
         output_dir: str | os.PathLike,
-        template_path: str = "multifile",
+        template_path: str,
         file_ext: str = "html",
         matrix_base_name="index",
     ):
         self.output_dir = output_dir
-        self.template_path = template_path or "multifile"
         templates_base_dir = os.path.join(os.path.dirname(__file__), "templates")
         self.template_path = [
             os.path.join(templates_base_dir, t) for t in template_path.split(",")


### PR DESCRIPTION
Changed default template path to 'multifile,.'
so the placeholder templates can use the non-
multifile partial templates. After the placeholder templates are 
replaced with the real ones, we should modify this
default path, if needed.

Fixes #179.