### PR TITLE
Mastodon API node mixin

### DIFF
--- a/src/feditest/nodedrivers/mastodon/manual.py
+++ b/src/feditest/nodedrivers/mastodon/manual.py
@@ -1,0 +1,22 @@
+
+from typing import Any
+
+from feditest import nodedriver
+from feditest.nodedrivers.mastodon.mixin import MastodonApiMixin
+from feditest.protocols import Node, NodeDriver
+from feditest.protocols.activitypub import ActivityPubNode
+
+
+class MastodonManualNode(MastodonApiMixin, ActivityPubNode):
+    ...
+    
+@nodedriver
+class MastodonManualNodeDriver(NodeDriver):
+    """
+    Expects a manually-provisioned Mastodon node.
+    """
+
+    def _provision_node(self, rolename: str, parameters: dict[str, Any]) -> Node:
+        return MastodonManualNode(rolename, parameters, self)
+
+    def _unprovision_node(self, node: Node) -> None: ...

--- a/src/feditest/nodedrivers/mastodon/ubos.py
+++ b/src/feditest/nodedrivers/mastodon/ubos.py
@@ -2,15 +2,27 @@
 from typing import Any
 
 from feditest import nodedriver
-from feditest.protocols import Node
+from feditest.nodedrivers.mastodon.mixin import MastodonApiMixin
+from feditest.protocols import Node, NodeDriver
 from feditest.protocols.fediverse import FediverseNode
 from feditest.ubos import UbosNodeDriver
 
 
-class MastodonUbosNode(FediverseNode):
+class MastodonUbosNode(MastodonApiMixin, FediverseNode):
     """
     A Node running Mastodon, instantiated with UBOS.
     """
+
+    def __init__(self, rolename: str, parameters: dict[str, Any], node_driver: NodeDriver):
+        # TODO Automatic actor provisioning
+        # Use parameters to determine which actors to provision 
+        # with UBOS with which information
+        # Copy and modify the parameters for usage by the MastodonApiMixin
+        # Must invoke base class constructors explicitly since Python will
+        # normally only call the first __init__ it finds in the MRO.
+        # super().__init__(rolename, parameters, node_driver)
+        MastodonApiMixin.__init__(self, rolename, parameters, node_driver)
+        FediverseNode.__init__(self, rolename, parameters, node_driver)
 
     def obtain_actor_document_uri(self, actor_rolename: str | None = None) -> str:
         return f"https://{self.hostname}/users/{self.parameter('adminid') }"


### PR DESCRIPTION
I factored out the Mastodon API-related code into a "mixin" class. I used the mixin to create a manually-provisioned Mastodon node and I also added it to the UBOS-based node. For now, the account parameters for UBOS should be configured explicitly. If you implement dynamic actor creation that can be supported too. See the example test plan in the feditest-tests-fediverse repo for more details about configuration.