### PR TITLE
CSS for fragments identifying tests per #202

### DIFF
--- a/src/feditest/templates/default/partials/test_matrix/table.jinja2
+++ b/src/feditest/templates/default/partials/test_matrix/table.jinja2
@@ -31,7 +31,7 @@
                 {{ column_headings("{0} tests in {1} sessions (alphabetical order)".format(len(run.test_meta), len(run.sessions))) }}
             </thead>
             <tbody>
-{%- for _, test_meta in sorted(run.test_meta.items()) %}
+{%- for test_index, ( _, test_meta ) in enumerate(sorted(run.test_meta.items())) %}
                 <tr>
                     <td class="namedesc">
                         <span class="name">{{ permit_line_breaks_in_identifier(test_meta.name) }}</span>
@@ -39,7 +39,7 @@
                         <span class="description">{{ test_meta.description }}</span>
 {%-     endif %}
                     </td>
-{%-     for run_session in run.sessions %}
+{%-     for session_index, run_session in enumerate(run.sessions) %}
 {%-         for result in get_results_for(run, run_session, test_meta) %}
 {%              include "partials/test_matrix/testresult.jinja2" %}
 {%-         endfor %}

--- a/src/feditest/templates/default/partials/test_matrix/testresult.jinja2
+++ b/src/feditest/templates/default/partials/test_matrix/testresult.jinja2
@@ -1,9 +1,9 @@
 {%- if result %}
-<td class="status {{ result.css_classes() }} moreinfo">
+<td class="status {{ result.css_classes() }} moreinfo" id="test-{{ session_index }}-{{ test_index }}">
     <div>{{ result.short_title() }}</div>
 </td>
 {%- else %}
-<td class="status passed">
+<td class="status passed" id="test-{{ session_index }}-{{ test_index }}">
     <div>Passed</div>
 </td>
 {%- endif %}

--- a/src/feditest/templates/default/partials/test_session/results.jinja2
+++ b/src/feditest/templates/default/partials/test_session/results.jinja2
@@ -40,7 +40,7 @@
 {%-     for test_index, run_test in enumerate(run_session.run_tests) %}
 {%-         set plan_test_spec = plan_session.tests[run_test.plan_test_index] %}
 {%-         set test_meta = run.test_meta[plan_test_spec.name] %}
-        <div class="test">
+        <div class="test" id="test-{{ test_index }}">
             <h4><span class="prefix">Test:</span> {{ test_meta.name }}</h4>
 {%-         if test_meta.description %}
             <div class="description">{{ test_meta.description}}</div>

--- a/src/feditest/templates/default/static/feditest.css
+++ b/src/feditest/templates/default/static/feditest.css
@@ -177,12 +177,13 @@ div.feditest.session > h3::before {
 
 .feditest .status.moreinfo div:hover::after,
 .feditest .status.moreinfo label:hover::after {
-        padding: 10px;
+    padding: 10px;
     border: 1px solid #808080;
     position: absolute;
     z-index: 1;
     text-align: left;
     white-space: pre-wrap;
+    color: var(--pico-color);
     background-color: var(--pico-background-color);
 }
 
@@ -451,4 +452,20 @@ div.feditest.mobile {
 
 .feditest .percentage {
     font-weight: 200;
+}
+
+:target {
+    border: 2px solid black;
+    background: #ffffd0;
+    padding: 0 2ex;
+}
+
+@media (prefers-color-scheme: dark) {
+    table.feditest.summary td.status {
+        color: black;
+    }
+    :target {
+        border: 2px solid white;
+        background: #282828;
+    }
 }


### PR DESCRIPTION
CSS :target highlight if a specific test result is identified in a URL fragment Also: fixed text color in hover popup in dark mode