### PR TITLE
Allow overriding PYTHON executable path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 UNAME:=$(shell uname -s | tr [A-Z] [a-z])
 BRANCH:=$(shell git branch --show-current)
 VENV:=venv.$(UNAME).$(BRANCH)
-PYTHON:=python
+PYTHON?=python
 
 build : venv
 	$(VENV)/bin/pip install .

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@
 # NOTE: This does not add the venv to your $PATH. You have to do that yourself if you want that.
 #
 
-UNAME:=$(shell uname -s | tr [A-Z] [a-z])
-BRANCH:=$(shell git branch --show-current)
-VENV:=venv.$(UNAME).$(BRANCH)
+UNAME?=$(shell uname -s | tr [A-Z] [a-z])
+BRANCH?=$(shell git branch --show-current)
+VENV?=venv.$(UNAME).$(BRANCH)
 PYTHON?=python
 
 build : venv


### PR DESCRIPTION
I tried to run `make venv` in an environment with only `python3`, no installed `python`.  It told me to try running with the `PYTHON` environment variable.  However, this didn't actually work.  This variable should be overridable from the command line.