### PR TITLE
Use UTC constant instead of alias, compatibility with Python 3.10

### DIFF
--- a/src/feditest/protocols/web/__init__.py
+++ b/src/feditest/protocols/web/__init__.py
@@ -1,7 +1,7 @@
 """
 """
 
-from datetime import date, datetime, UTC
+from datetime import date, datetime, timezone
 from typing import Any, Callable, List, final
 from feditest.protocols import Node, NotImplementedByNodeError
 from feditest.protocols.web.traffic import HttpRequest, HttpRequestResponsePair, ParsedUri
@@ -11,7 +11,7 @@ class WebServerLog:
     """
     A list of logged HTTP requests to a web server.
     """
-    def __init__(self, time_started: date = datetime.now(UTC), entries: List[HttpRequestResponsePair] | None = None ):
+    def __init__(self, time_started: date = datetime.now(timezone.utc), entries: List[HttpRequestResponsePair] | None = None ):
         self._time_started : date = time_started
         self._web_log_entries : List[HttpRequestResponsePair] = entries or []
 

--- a/src/feditest/protocols/web/traffic.py
+++ b/src/feditest/protocols/web/traffic.py
@@ -2,7 +2,7 @@
 Abstract data types that capture what is exchanged over HTTP.
 """
 
-from datetime import UTC, date, datetime
+from datetime import date, datetime, timezone
 from dataclasses import dataclass
 from multidict import MultiDict
 
@@ -19,7 +19,7 @@ class HttpRequest:
     accept_header : str | None = None
     payload : bytes | None = None
     content_type : str | None = None
-    when_started: date = datetime.now(UTC)
+    when_started: date = datetime.now(timezone.utc)
 
 
 @dataclass
@@ -30,7 +30,7 @@ class HttpResponse:
     http_status : int
     response_headers: MultiDict # keys are lowercased
     payload : bytes | None = None
-    when_completed: date | None = datetime.now(UTC)
+    when_completed: date | None = datetime.now(timezone.utc)
 
 
     def content_type(self):

--- a/src/feditest/testrun.py
+++ b/src/feditest/testrun.py
@@ -7,7 +7,7 @@ import platform
 import time
 import traceback
 from abc import ABC
-from datetime import UTC, datetime, timezone
+from datetime import datetime, timezone
 from typing import Any, Type, cast
 
 import feditest.testruncontroller
@@ -148,7 +148,7 @@ class TestRunFunction(TestRunTest):
 
 
     def run(self, controller: feditest.testruncontroller.TestRunController) -> None:
-        self.started = datetime.now(UTC)
+        self.started = datetime.now(timezone.utc)
         info(f'Started test { self.str_in_session() }')
 
         args = {}
@@ -164,7 +164,7 @@ class TestRunFunction(TestRunTest):
         except Exception as e:
             self.exception = e
         finally:
-            self.ended = datetime.now(UTC)
+            self.ended = datetime.now(timezone.utc)
             if self.exception:
                 error(f'Ended test { self.str_in_session() } with Exception:\n' + ''.join(traceback.format_exception(self.exception)))
             else:
@@ -188,7 +188,7 @@ class TestRunStepInClass(HasStartEndResults):
 
 
     def run(self, test_instance: object, controller: feditest.testruncontroller.TestRunController) -> None:
-        self.started = datetime.now(UTC)
+        self.started = datetime.now(timezone.utc)
         info(f'Started step { self.str_in_session() }')
 
         try:
@@ -197,7 +197,7 @@ class TestRunStepInClass(HasStartEndResults):
         except Exception as e:
             self.exception = e
         finally:
-            self.ended = datetime.now(UTC)
+            self.ended = datetime.now(timezone.utc)
             if self.exception:
                 error(f'Ended step { self.str_in_session() } with Exception:\n' + ''.join(traceback.format_exception(self.exception)))
             else:
@@ -220,7 +220,7 @@ class TestRunClass(TestRunTest):
 
 
     def run(self, controller: feditest.testruncontroller.TestRunController) -> None:
-        self.started = datetime.now(UTC)
+        self.started = datetime.now(timezone.utc)
         info(f'Started test { self.str_in_session() }')
 
         args = {}
@@ -258,7 +258,7 @@ class TestRunClass(TestRunTest):
         except Exception as e: # This should not happen
             self.exception = e
         finally:
-            self.ended = datetime.now(UTC)
+            self.ended = datetime.now(timezone.utc)
             if self.exception:
                 error(f'Ended test { self.str_in_session() } with Exception:\n' + ''.join(traceback.format_exception(self.exception)))
             else:
@@ -289,7 +289,7 @@ class TestRunSession(HasStartEndResults):
 
         return: the number of tests run, or a negative number to signal that not all tests were run or completed
         """
-        self.started = datetime.now(UTC)
+        self.started = datetime.now(timezone.utc)
         info(f'Started TestRunSession for TestPlanSession { self }')
 
         try:
@@ -342,7 +342,7 @@ class TestRunSession(HasStartEndResults):
             else:
                 info(f'Skipping TestRunSession { self }: no tests')
 
-            self.ended = datetime.now(UTC)
+            self.ended = datetime.now(timezone.utc)
             if self.exception:
                 if isinstance(self.exception, OSError):
                     error(f'Ended TestRunSession { self } with Exception: {self.exception}')
@@ -379,7 +379,7 @@ class TestRun(HasStartEndResults):
         """
         Run a TestPlan.
         """
-        self.started = datetime.now(UTC)
+        self.started = datetime.now(timezone.utc)
         info(f'Started TestRun { self }')
 
         try:
@@ -400,7 +400,7 @@ class TestRun(HasStartEndResults):
         except Exception as e: # This should not happen
             self.exception = e
         finally:
-            self.ended = datetime.now(UTC)
+            self.ended = datetime.now(timezone.utc)
             if self.exception:
                 error(f'Ended TestRun { self } with Exception:\n' + ''.join(traceback.format_exception(self.exception)))
             else:


### PR DESCRIPTION
This is the outcome of a quick experiment to see if feditest actually does work with Python 3.10, #199.  It turns out that the `UTC` alias was added to `datetime` in version 3.11.  (See [docs](https://docs.python.org/3/library/datetime.html) section "Constants".)

This still isn't enough to make feditest work, so it's not clear that this should be merged.  I might have time to investigate further.