### PR TITLE
Memoise previous responses to prompt for account URIs

### DIFF
--- a/src/feditest/protocols/__init__.py
+++ b/src/feditest/protocols/__init__.py
@@ -73,6 +73,10 @@ class Node(ABC):
         return self._parameters.get(name)
 
 
+    def set_parameter(self, name:str, value:Any) -> None:
+        return self._parameters.update({name: value})
+
+
     def __str__(self) -> str:
         return f'"{ type(self).__name__}" in constellation role "{self.rolename}"'
 

--- a/src/feditest/protocols/webfinger/__init__.py
+++ b/src/feditest/protocols/webfinger/__init__.py
@@ -34,6 +34,7 @@ class WebFingerServer(WebServer):
                     self.parameter('existing-account-uri'),
                     http_https_acct_uri_validate)
         assert ret
+        self.set_parameter('existing-account-uri', ret)
         return ret
 
 
@@ -56,6 +57,7 @@ class WebFingerServer(WebServer):
                     self.parameter('nonexisting-account-uri'),
                     http_https_acct_uri_validate)
         assert ret
+        self.set_parameter('nonexisting-account-uri', ret)
         return ret
 
 


### PR DESCRIPTION
This fixes #200 by remembering values for valid and invalid accounts entered by the user.