### PR TITLE
Fixed error with unsupported delete_on_close keyword arg

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -71,7 +71,7 @@ def test_save_restore():
     for i in range(5):
          r1.obtain_new_hostinfo('')
 
-    file = tempfile.NamedTemporaryFile(delete=True, delete_on_close=False).name
+    file = tempfile.NamedTemporaryFile(delete=True).name
     r1.save(file)
     r2 = Registry.load(file)
 


### PR DESCRIPTION
Was seeing:
```
FAILED tests/test_registry.py::test_save_restore - TypeError: NamedTemporaryFile() 
got an unexpected keyword argument 'delete_on_close'
```