### PR TITLE
Renamed TestException

### DIFF
--- a/tests/test_report_node_driver_errors.py
+++ b/tests/test_report_node_driver_errors.py
@@ -4,17 +4,27 @@ Test that NodeDriver errors are reported in the test reports
 
 from typing import Any
 
-import pytest
-
 import feditest
+import pytest
 from feditest import nodedriver
-from feditest.testplan import TestPlan, TestPlanConstellation, TestPlanConstellationNode, TestPlanSession, TestPlanTestSpec
+from feditest.protocols import Node, NodeDriver
+from feditest.testplan import (
+    TestPlan,
+    TestPlanConstellation,
+    TestPlanConstellationNode,
+    TestPlanSession,
+    TestPlanTestSpec,
+)
 from feditest.testrun import TestRun
 from feditest.testruncontroller import AutomaticTestRunController
-from feditest.testruntranscript import JsonTestRunTranscriptSerializer, SummaryTestRunTranscriptSerializer, TapTestRunTranscriptSerializer
-from feditest.protocols import Node, NodeDriver
+from feditest.testruntranscript import (
+    JsonTestRunTranscriptSerializer,
+    SummaryTestRunTranscriptSerializer,
+    TapTestRunTranscriptSerializer,
+)
 
-class TestException(Exception):
+
+class NodeDriverTestException(Exception):
     pass
 
 
@@ -42,7 +52,7 @@ def init():
     @nodedriver
     class Faulty_NodeDriver(NodeDriver):
         def _provision_node(self, rolename: str, parameters: dict[str,Any]) -> Node:
-            raise TestException()
+            raise NodeDriverTestException()
 
     feditest._loading_node_drivers = False
 
@@ -61,10 +71,7 @@ def test_faulty_node_driver_reportiung() -> None:
     run = TestRun(plan)
     controller = AutomaticTestRunController(run)
 
-    try:
-        run.run(controller)
-    except:
-        pass
+    run.run(controller)
 
     transcript : feditest.testruntranscript.TestRunTranscript = run.transcribe()
     # transcript.save('transcript.json')
@@ -82,4 +89,4 @@ def test_faulty_node_driver_reportiung() -> None:
     json_serializer = JsonTestRunTranscriptSerializer(transcript)
     j : str = json_serializer.write_to_string()
     # print(j)
-    assert '"type": "TestException"' in j
+    assert f'"type": "{NodeDriverTestException.__name__}"' in j


### PR DESCRIPTION
The `TestException` was confusing pytest test discovery (at least in a VS Code context) because of the "Test*" naming convention for test classes. 