### PR TITLE
Initial pre-commit support.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,11 +53,11 @@ repos:
 #       # though tests might be invalidated if you were to say change a data file
 #       always_run: true
 
-# - repo: local
-#   hooks:
-#   -   id: nocommit
-#       name: NOCOMMIT check
-#       entry: NOCOMMIT
-#       language: pygrep
-#       exclude: .pre-commit-config.yaml
-#       types: [text]
+- repo: local
+  hooks:
+  -   id: nocommit
+      name: NOCOMMIT check
+      entry: NOCOMMIT
+      language: pygrep
+      exclude: .pre-commit-config.yaml
+      types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,61 @@
+default_install_hook_types:
+- pre-push
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  # - id: trailing-whitespace
+  #   args: [--markdown-linebreak-ext=md]
+  # - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: check-yaml
+  - id: sort-simple-yaml
+  - id: check-added-large-files
+
+# - repo: https://github.com/psf/black
+#   rev: 23.3.0
+#   hooks:
+#   - id: black
+#     language_version: python3.11
+#     args:
+#     - --config=pyproject.toml
+
+# - repo: https://github.com/pycqa/isort
+#   rev: 5.12.0
+#   hooks:
+#     - id: isort
+#       name: isort (python)
+#       args: ["--profile", "black", "--filter-files"]
+
+# - repo: https://github.com/astral-sh/ruff-pre-commit
+#   # Ruff version.
+#   rev: v0.6.0
+#   hooks:
+#     # Run the linter.
+#     - id: ruff
+#     # Run the formatter.
+#     - id: ruff-format
+
+# - repo: local
+#   hooks:
+#     - id: pytest
+#       name: pytest
+#       entry: pytest
+#       language: system
+#       #name: pytest
+#       entry: /Users/bate/.pyenv/shims/pytest
+#       #language: script
+#       pass_filenames: false
+#       # alternatively you could `types: [python]` so it only runs when python files change
+#       # though tests might be invalidated if you were to say change a data file
+#       always_run: true
+
+# - repo: local
+#   hooks:
+#   -   id: nocommit
+#       name: NOCOMMIT check
+#       entry: NOCOMMIT
+#       language: pygrep
+#       exclude: .pre-commit-config.yaml
+#       types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,12 @@
 default_install_hook_types:
 - pre-push
 
+default_language_version:
+    python: python3.11
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   # - id: trailing-whitespace
   #   args: [--markdown-linebreak-ext=md]
@@ -14,15 +17,14 @@ repos:
   - id: check-added-large-files
 
 # - repo: https://github.com/psf/black
-#   rev: 23.3.0
+#   rev: 24.8.0
 #   hooks:
 #   - id: black
-#     language_version: python3.11
 #     args:
 #     - --config=pyproject.toml
 
 # - repo: https://github.com/pycqa/isort
-#   rev: 5.12.0
+#   rev: 5.13.2
 #   hooks:
 #     - id: isort
 #       name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
   "jinja2",
   "pyhamcrest",
   "pytest",
-  "mastodon.py"
+  "mastodon.py",
+  "pre-commit"
 ]
 description = "Testing federated protocols"
 readme = "README-PyPI.md"
@@ -64,4 +65,3 @@ exclude = [
 [tool.pylint."MESSAGES CONTROL"]
 max-line-length=120
 disable="arguments-renamed, empty-docstring, global-variable-not-assigned, line-too-long, missing-class-docstring, missing-function-docstring, too-few-public-methods, too-many-arguments"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,6 @@ exclude = [
 [tool.pylint."MESSAGES CONTROL"]
 max-line-length=120
 disable="arguments-renamed, empty-docstring, global-variable-not-assigned, line-too-long, missing-class-docstring, missing-function-docstring, too-few-public-methods, too-many-arguments"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]


### PR DESCRIPTION
See also: #259

Most of the checks are currently commented out because it's going to "clean up" a lot of files (and will flag many more as needing manual intervention). I thought I'd enable them one at a time and submit a PR with the changes. I also need to see how to use the pytest support given our somewhat ad hoc venv approach (the checks run in their own isolated virtual environment).

To use this:

```
pip install pre-commit  # or however you are installing feditest dependencies

# add a git hook to invoke pre-commit before a push
# the pre-push git hook is defined as the default
pre-commit install 

# to run manually
pre-commit run -a

# to run a specific check manually
pre-commit run -a <check-id>

# to bypass the pre-commit hook
git push --no-verify