### PR TITLE
Make the custom CA work with Mastodon.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
   "jinja2",
   "pyhamcrest",
   "pytest",
-  "mastodon.py"
+  "mastodon.py",
+  "types-requests"
 ]
 description = "Testing federated protocols"
 readme = "README-PyPI.md"

--- a/src/feditest/protocols/webfinger/__init__.py
+++ b/src/feditest/protocols/webfinger/__init__.py
@@ -101,6 +101,7 @@ class WebFingerClient(WebClient):
         """
         raise NotImplementedByNodeError(self, WebFingerClient.perform_webfinger_query)
 
+
     def construct_webfinger_query_for(
         self,
         server_prefix: str,
@@ -110,9 +111,11 @@ class WebFingerClient(WebClient):
         query = (
             f"{server_prefix}/.well-known/webfinger?resource={quote(resource_uri)}"
         )
-        if query:
-            query += "&rel=" + "&rel=".join(quote(rel) for rel in rels)
+        if query and rels:
+            for rel in rels:
+                query += "&rel=" + quote(rel)
         return query
+
 
     def construct_webfinger_uri_for(
         self,
@@ -150,12 +153,14 @@ class WebFingerClient(WebClient):
 
         return uri
 
+
     class UnsupportedUriSchemeError(RuntimeError):
         """
         Raised when a WebFinger resource uses a scheme other than http, https, acct
         """
         def __init__(self, resource_uri: str):
             self.resource_uri = resource_uri
+
 
     class CannotDetermineWebfingerHostError(RuntimeError):
         """

--- a/src/feditest/registry.py
+++ b/src/feditest/registry.py
@@ -65,7 +65,7 @@ class Registry(msgspec.Struct):
     @staticmethod
     def create(rootdomain: str | None = None) -> 'Registry':
         if not rootdomain:
-            rootdomain = f'{ random.randint(1000, 9999) }.lan'
+            rootdomain = f'{ random.randint(10000, 99999) }.lan'
 
         ret = Registry(ca=RegistryRoot(domain=rootdomain))
         return ret
@@ -110,7 +110,7 @@ class Registry(msgspec.Struct):
 
         if not self.ca.cert:
             ca_subject = x509.Name([
-                x509.NameAttribute(x509.NameOID.COMMON_NAME, "feditest-user.example"),
+                x509.NameAttribute(x509.NameOID.COMMON_NAME, "feditest-local-ca." + self.ca.domain),
             ])
             ca_key = cast(rsa.RSAPrivateKey, load_pem_private_key(self.ca.key.encode('utf-8'), password=None))
             now = datetime.now(UTC)
@@ -174,20 +174,22 @@ class Registry(msgspec.Struct):
                 encryption_algorithm=NoEncryption()).decode('utf-8')
 
         if ret.cert is None:
+            self.obtain_registry_root() # make sure we have it
+            ca_cert = x509.load_pem_x509_certificate(cast(str,self.ca.cert).encode('utf-8'))
+            ca_key = cast(rsa.RSAPrivateKey, load_pem_private_key(cast(str,self.ca.key).encode('utf-8'), password=None))
+
             host_key =  cast(rsa.RSAPrivateKey, load_pem_private_key(ret.key.encode('utf-8'), password=None))
             host_subject = x509.Name([
                 x509.NameAttribute(x509.NameOID.COMMON_NAME, host),
             ])
-            host_csr = x509.CertificateSigningRequestBuilder().subject_name(host_subject
-                ).sign(host_key, hashes.SHA256())
-
-            self.obtain_registry_root() # make sure we have it
-            ca_cert = x509.load_pem_x509_certificate(cast(str,self.ca.cert).encode('utf-8'))
-            ca_key = cast(rsa.RSAPrivateKey, load_pem_private_key(cast(str,self.ca.key).encode('utf-8'), password=None))
+            host_san = x509.SubjectAlternativeName([
+                x509.DNSName(host)
+            ])
             now = datetime.now(UTC)
-            host_cert = x509.CertificateBuilder().subject_name(host_csr.subject
+            host_cert = x509.CertificateBuilder().subject_name(host_subject
                 ).issuer_name(ca_cert.subject
-                ).public_key(host_csr.public_key()
+                ).add_extension(host_san, critical=False
+                ).public_key(host_key.public_key()
                 ).serial_number(x509.random_serial_number()
                 ).not_valid_before(now
                 ).not_valid_after(now + timedelta(days=365)  # Expires after 1 year


### PR DESCRIPTION
This is overall improving things with the Mastodon Node, although more work remains.

* Make the random domain a bit longer
* Better name for our custom CA
* Add x509 SubjectAlternativeName to cert: apparently python ssl needs it
* Added types-requests dependency to make mypy happy
* Mastodon.py can now create the OAuth app using our custom CA