### PR TITLE
NGI - Updating licensing aspects according to REUSE

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/feditest/__init__.py
+++ b/src/feditest/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Core module.
 """

--- a/src/feditest/cli/__init__.py
+++ b/src/feditest/cli/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Main entry point for CLI invocation
 """

--- a/src/feditest/cli/commands/convert_transcript.py
+++ b/src/feditest/cli/commands/convert_transcript.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Convert a TestRunTranscript to a different format
 """

--- a/src/feditest/cli/commands/create_constellation.py
+++ b/src/feditest/cli/commands/create_constellation.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Combine node definitions into a constellation.
 """

--- a/src/feditest/cli/commands/create_session_template.py
+++ b/src/feditest/cli/commands/create_session_template.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Create a template for a test session. This is very similar to list-tests, but the output is to be used
 as input for generate-testplan.

--- a/src/feditest/cli/commands/create_testplan.py
+++ b/src/feditest/cli/commands/create_testplan.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Create a test plan.
 """

--- a/src/feditest/cli/commands/info.py
+++ b/src/feditest/cli/commands/info.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Provide information on a variety of objects
 """

--- a/src/feditest/cli/commands/list-templates.py
+++ b/src/feditest/cli/commands/list-templates.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 List the available templates
 """

--- a/src/feditest/cli/commands/list_nodedrivers.py
+++ b/src/feditest/cli/commands/list_nodedrivers.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 List the available drivers for nodes that can be tested
 """

--- a/src/feditest/cli/commands/list_tests.py
+++ b/src/feditest/cli/commands/list_tests.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 List the available tests
 """

--- a/src/feditest/cli/commands/run.py
+++ b/src/feditest/cli/commands/run.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Run one or more tests
 """

--- a/src/feditest/cli/commands/version.py
+++ b/src/feditest/cli/commands/version.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Show version
 """

--- a/src/feditest/nodedrivers/__init__.py
+++ b/src/feditest/nodedrivers/__init__.py
@@ -1,2 +1,7 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """

--- a/src/feditest/nodedrivers/imp/__init__.py
+++ b/src/feditest/nodedrivers/imp/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 An in-process Node implementation for now.
 """

--- a/src/feditest/nodedrivers/manual/__init__.py
+++ b/src/feditest/nodedrivers/manual/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 A NodeDriver that supports all protocols but doesn't automate anything.
 """

--- a/src/feditest/nodedrivers/mastodon/__init__.py
+++ b/src/feditest/nodedrivers/mastodon/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/nodedrivers/mastodon/ubos.py
+++ b/src/feditest/nodedrivers/mastodon/ubos.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/nodedrivers/saas/__init__.py
+++ b/src/feditest/nodedrivers/saas/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 A NodeDriver that supports all protocols but doesn't automate anything and assumes the
 Node under test exists as a website that we don't have/can provision/unprovision.

--- a/src/feditest/nodedrivers/sandbox/__init__.py
+++ b/src/feditest/nodedrivers/sandbox/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/nodedrivers/wordpress/__init__.py
+++ b/src/feditest/nodedrivers/wordpress/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/nodedrivers/wordpress/ubos.py
+++ b/src/feditest/nodedrivers/wordpress/ubos.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/protocols/__init__.py
+++ b/src/feditest/protocols/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Define interfaces to interact with the nodes in the constellation being tested
 """

--- a/src/feditest/protocols/activitypub/__init__.py
+++ b/src/feditest/protocols/activitypub/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Abstractions for the ActivityPub protocol
 """

--- a/src/feditest/protocols/activitypub/utils.py
+++ b/src/feditest/protocols/activitypub/utils.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 ActivityPub testing utils
 """

--- a/src/feditest/protocols/fediverse/__init__.py
+++ b/src/feditest/protocols/fediverse/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Abstractions for nodes that speak today's Fediverse protocol stack.
 """

--- a/src/feditest/protocols/fediverse/utils.py
+++ b/src/feditest/protocols/fediverse/utils.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Fediverse testing utils
 """

--- a/src/feditest/protocols/sandbox/__init__.py
+++ b/src/feditest/protocols/sandbox/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Abstractions for the toy "Sandbox" protocol.
 """

--- a/src/feditest/protocols/web/__init__.py
+++ b/src/feditest/protocols/web/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/protocols/web/traffic.py
+++ b/src/feditest/protocols/web/traffic.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Abstract data types that capture what is exchanged over HTTP.
 """

--- a/src/feditest/protocols/webfinger/__init__.py
+++ b/src/feditest/protocols/webfinger/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Abstractions for the WebFinger protocol
 """

--- a/src/feditest/protocols/webfinger/traffic.py
+++ b/src/feditest/protocols/webfinger/traffic.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 """
 

--- a/src/feditest/protocols/webfinger/utils.py
+++ b/src/feditest/protocols/webfinger/utils.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Webfinger testing utils
 """

--- a/src/feditest/registry.py
+++ b/src/feditest/registry.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Registry and certificate authority for locally-allocated hostnames and their
 certificates.

--- a/src/feditest/reporting.py
+++ b/src/feditest/reporting.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Reporting functionality
 """

--- a/src/feditest/testplan.py
+++ b/src/feditest/testplan.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Classes that represent a TestPlan and its parts.
 """

--- a/src/feditest/testrun.py
+++ b/src/feditest/testrun.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Classes that represent a running TestPlan and its its parts.
 """

--- a/src/feditest/testruncontroller.py
+++ b/src/feditest/testruncontroller.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Classes that know how to control a TestRun.
 """

--- a/src/feditest/testruntranscript.py
+++ b/src/feditest/testruntranscript.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 import contextlib
 import io
 import json

--- a/src/feditest/tests.py
+++ b/src/feditest/tests.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Classes that represent tests.
 """

--- a/src/feditest/ubos/__init__.py
+++ b/src/feditest/ubos/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Nodes managed via UBOS Gears https://ubos.net/
 """

--- a/src/feditest/utils.py
+++ b/src/feditest/utils.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Utility functions
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 # def pytest_pycollect_makeitem(collector, name, obj):
 #     module_name = getattr(obj, "__module__") if hasattr(obj, "__module__") else None
 #     if module_name and module_name.startswith("feditest."):

--- a/tests/test_10_create_test_plan_constallation.py
+++ b/tests/test_10_create_test_plan_constallation.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test the equivalent of `feditest create-constellation`
 """

--- a/tests/test_10_register_nodedrivers.py
+++ b/tests/test_10_register_nodedrivers.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test that @nodedriver annotations register NodeDrivers correctly.
 """

--- a/tests/test_10_register_tests.py
+++ b/tests/test_10_register_tests.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test that @test and @step annotations register their functions/classes/methods correctly.
 """

--- a/tests/test_20_create_test_plan_session_template.py
+++ b/tests/test_20_create_test_plan_session_template.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test the equivalent of `feditest create-session-template`
 """

--- a/tests/test_30_create_testplan.py
+++ b/tests/test_30_create_testplan.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test the equivalent of `feditest create-testplan`
 """

--- a/tests/test_mastodon_node.py
+++ b/tests/test_mastodon_node.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 import json
 import os
 import re

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test the UBOS host registry / CA
 """

--- a/tests/test_report_node_driver_errors.py
+++ b/tests/test_report_node_driver_errors.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023-2024 Johannes Ernst
+# SPDX-FileCopyrightText: 2023-2024 Steve Bate
+#
+# SPDX-License-Identifier: MIT
+
 """
 Test that NodeDriver errors are reported in the test reports
 """


### PR DESCRIPTION
Hello,

I work for the Free Software Foundation Europe (FSFE), and we have been working with the NGI framework, helping projects with their licensing and copyright management. After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information. [REUSE](https://reuse.software/) is an FSFE-developed initiative intended to make licensing easier by establishing a single way to display all copyright and licensing information through comment headers on source files that can be human- and machine-readable.

## REUSE Features:
### Copyright and Licensing Information in each file

One of the main features of REUSE is that each file in the repository contains copyright and license information with the help of a comment header. To serve as a guideline and a practical example of how REUSE looks, I have added the header to some of the files in your repository, but some directories such as `src/feditest/templates/` still need such info. I've taken the copyright information from the file `pyproject.toml` So, please double-check that the personal information in the headers is correct and consistent, otherwise, please update that information in the headers. In case you want to license certain files under a different license, special attention should also be paid to that aspect and such files should contain the appropriate SPDX tag.

And, please remember that you can also change the [year in the headers](https://reuse.readthedocs.io/en/stable/man/reuse-annotate.html#cmdoption-y) depending on your [preference](https://reuse.software/faq/#years-copyright).

Please note that REUSE has also an option to add this legal information for [binary and uncommentable files](https://reuse.software/faq/#uncommentable-file), as well as for [insignificant files ](https://reuse.software/faq/#uncopyrightable)- no copyrightable files such as `.gitignore`. An appropriate license for the documentation files in your repository is also encouraged.

### LICENSES directory in the root of the project with the licenses used on the repository:

I included in this directory a file with the text of the MIT license. I did not do anything with the existing `LICENSE` file in the root of the directory. It is up to you if you want to keep it or delete it, however, this won't affect the REUSE specification. Please also be aware, that if some pieces of your project use a different license, such license text should be added to the `LICENSES/` directory as well as to the specific files.

Please feel free to check the [REUSE documentation](https://reuse.readthedocs.io/en/stable/) and the [helper tool ](https://reuse.software/dev/#tool), and if you are interested in making your project REUSE compliant, please add the legal information to the missing files. I am also available if you want support with the process.

## Wide range of tools

In case you find REUSE useful, we offer other tools to help you continuously check and display compliance with the REUSE guidelines. For instance, you can automatically run reuse lint on every commit as[ a pre-commit hook](https://reuse.software/dev/#pre-commit-hook) for Git. And, it can be easily [integrated into your existing CI/CD processes](https://reuse.software/dev/#ci) to continuously test your repository and its changes for REUSE compliance

Hope that helps and thank you very much for the amazing job!