### PR TITLE
Solve mystery ruff problem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,6 @@ disable="arguments-renamed, empty-docstring, global-variable-not-assigned, line-
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+
+[tool.ruff]
+target-version = "py311"


### PR DESCRIPTION
This solves my mystery ruff problem where ruff would complain about ExceptionGroup not existing, although I'm running python 3.11. Why I need it and others don't IDK.