### PR TITLE
Use new UBOS `allow_private_addresses` customizationpoint on Mastodon and make test work

### DIFF
--- a/src/feditest/nodedrivers/mastodon/__init__.py
+++ b/src/feditest/nodedrivers/mastodon/__init__.py
@@ -381,15 +381,9 @@ class NodeWithMastodonAPI(FediverseNode):
     def wait_for_object_in_inbox(self, actor_uri: str, object_uri: str, max_wait: float = 5.) -> None:
         trace('wait_for_object_in_inbox:')
         mastodon_client = self._get_mastodon_client_by_actor_uri(actor_uri)
+
         response = self._poll_until_result( # may throw
-            lambda: next(
-                (
-                    s
-                    for s in mastodon_client.timeline("local")
-                    if s.uri == object_uri
-                ),
-                None,
-            ),
+            lambda: any( s.uri == object_uri for s in mastodon_client.timeline_home(local=True, remote=True)),
             int(max_wait),
             1.0,
             f'Expected object { object_uri } has not arrived in inbox of actor { actor_uri }'

--- a/src/feditest/nodedrivers/mastodon/ubos.py
+++ b/src/feditest/nodedrivers/mastodon/ubos.py
@@ -277,6 +277,9 @@ class MastodonUbosNodeDriver(UbosNodeDriver):
                         "mastodon" : {
                             "singleusermode" : {
                                 "value" : False
+                            },
+                            "allowed_private_addresses" : {
+                                "value" : "192.168.1.1/16" # Allow testing in a Linux container
                             }
                         }
                     }

--- a/src/feditest/nodedrivers/mastodon/ubos.py
+++ b/src/feditest/nodedrivers/mastodon/ubos.py
@@ -120,7 +120,7 @@ class MastodonUbosNodeConfiguration(UbosNodeDeployConfiguration, NodeWithMastodo
             else:
                 start_delay = float(start_delay_1)
         else:
-            start_delay = 0.0
+            start_delay = 10.0 # 10 sec should be good enough
 
         if test_plan_node.parameter(BACKUPFILE_PAR):
             raise TestPlanNodeParameterMalformedError(BACKUP_APPCONFIGID_PAR, ' must not be given for MastodonUbosNodeDriver')

--- a/src/feditest/protocols/__init__.py
+++ b/src/feditest/protocols/__init__.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Any, cast, final
 
 from feditest.testplan import TestPlanConstellationNode, TestPlanNodeParameter, TestPlanNodeAccountField, TestPlanNodeNonExistingAccountField
-from feditest.reporting import warning, trace
+from feditest.reporting import info, warning
 from feditest.utils import hostname_validate, appname_validate, appversion_validate
 
 
@@ -352,6 +352,10 @@ class NodeConfiguration:
         return self._start_delay
 
 
+    def __str__(self) -> str:
+        return f'NodeConfiguration ({ type(self).__name__ }): node driver: "{ self.node_driver }", app: "{ self.app }", hostname: "{ self.hostname }"'
+
+
 class Node(ABC):
     """
     A Node is the interface through which FediTest talks to an application instance.
@@ -513,7 +517,7 @@ class NodeDriver(ABC):
         rolename: the name of this Node in the constellation
         config: the NodeConfiguration created with create_configuration
         """
-        trace(f'Provisioning node for role { rolename } with NodeDriver { self.__class__.__name__} and configuration { config }')
+        info(f'Provisioning node for role "{ rolename }" with { config }.')
         ret = self._provision_node(rolename, config, account_manager)
         return ret
 
@@ -526,6 +530,8 @@ class NodeDriver(ABC):
         """
         if node.node_driver != self :
             raise Exception(f"Node does not belong to this NodeDriver: { node.node_driver } vs { self }") # pylint: disable=broad-exception-raised
+
+        info(f'Unprovisioning node for role "{ node.rolename }" with NodeDriver "{ self.__class__.__name__}".')
         self._unprovision_node(node)
 
 

--- a/src/feditest/ubos/__init__.py
+++ b/src/feditest/ubos/__init__.py
@@ -23,7 +23,7 @@ from feditest.protocols import (
     NodeDriver
 )
 from feditest.registry import registry_singleton
-from feditest.reporting import error, info, trace, warning
+from feditest.reporting import error, trace, warning
 from feditest.testplan import TestPlanConstellationNode, TestPlanNodeParameter, TestPlanNodeParameterMalformedError, TestPlanNodeParameterRequiredError
 from feditest.utils import email_validate
 

--- a/src/feditest/ubos/__init__.py
+++ b/src/feditest/ubos/__init__.py
@@ -543,10 +543,10 @@ class UbosNodeDriver(NodeDriver):
             fullcmd = cmd
 
         if stdin_content:
-            info( f"Executing '{fullcmd}' with some stdin content" )
+            trace( f"Executing '{fullcmd}' with some stdin content" )
             ret = subprocess.run(fullcmd, shell=True, check=False, text=True, input=stdin_content, capture_output=capture_output)
         else:
-            info( f"Executing '{fullcmd}'")
+            trace( f"Executing '{fullcmd}'")
             ret = subprocess.run(fullcmd, shell=True, check=False, text=True, capture_output=capture_output)
 
         return ret

--- a/tests/feditest/mastodon_mastodon.py
+++ b/tests/feditest/mastodon_mastodon.py
@@ -40,12 +40,11 @@ class FollowTest:
     @step
     def follow(self):
         self.follower_node.make_a_follow_b(self.follower_actor_uri, self.leader_actor_uri, self.leader_node)
-        assert self.note_uri
 
 
     @step
     def leader_creates_note(self):
-        self.leader_note_uri = self.leader.make_create_note(self.leader_actor_uri, f"testing leader_creates_note {datetime.now()}")
+        self.leader_note_uri = self.leader_node.make_create_note(self.leader_actor_uri, f"testing leader_creates_note {datetime.now()}")
         assert self.leader_note_uri
 
 


### PR DESCRIPTION
so Mastodon will not block HTTP requests on the local network, which we need for testing purposes.

Closes #343 