### PR TITLE
Make progress on WordPress+ActivityPubPlugin. Not working yet.

### DIFF
--- a/src/feditest/nodedrivers/mastodon/__init__.py
+++ b/src/feditest/nodedrivers/mastodon/__init__.py
@@ -143,7 +143,6 @@ class AccountOnNodeWithMastodonAPI(Account): # this is intended to be abstract
     def __init__(self, role: str | None, userid: str):
         super().__init__(role)
         self.userid = userid
-        self._mastodon_user_client: Mastodon | None = None
 
 
     @property
@@ -186,6 +185,7 @@ class MastodonUserPasswordAccount(MastodonAccount):
         super().__init__(role, userid)
         self.password = password
         self.email = email
+        self._mastodon_user_client: Mastodon | None = None # Allocated as needed
 
 
     # Python 3.12 @override
@@ -213,6 +213,7 @@ class MastodonOAuthTokenAccount(MastodonAccount):
     def __init__(self, role: str | None, userid: str, oauth_token: str):
         super().__init__(role, userid)
         self.oauth_token = oauth_token
+        self._mastodon_user_client: Mastodon | None = None # Allocated as needed
 
 
     # Python 3.12 @override

--- a/src/feditest/nodedrivers/wordpress/__init__.py
+++ b/src/feditest/nodedrivers/wordpress/__init__.py
@@ -106,11 +106,10 @@ class WordPressAccount(AccountOnNodeWithMastodonAPI):
 
     @property
     def actor_uri(self):
-        return f'https://{ self.node.hostname }/author/{ self.userid }'
+        return f'https://{ self.node.hostname }/author/{ self.userid }/'
 
 
     def mastodon_user_client(self, node: NodeWithMastodonAPI) -> Mastodon:
-
         if self._mastodon_user_client is None:
             oauth_app = cast(MastodonOAuthApp,node._mastodon_oauth_app)
             self._ensure_oauth_token(node, oauth_app.client_id)

--- a/src/feditest/nodedrivers/wordpress/__init__.py
+++ b/src/feditest/nodedrivers/wordpress/__init__.py
@@ -5,18 +5,11 @@ import re
 from typing import cast
 
 from feditest.nodedrivers.mastodon import (
-    MastodonAccount,
-    MastodonNonExistingAccount,
+    AccountOnNodeWithMastodonAPI,
+    Mastodon, # Re-import from there to avoid duplicating the package import hackery
+    MastodonOAuthApp,
     NodeWithMastodonAPI,
-    NodeWithMastodonApiConfiguration,
-    EMAIL_ACCOUNT_FIELD,
-    OAUTH_TOKEN_ACCOUNT_FIELD,
-    PASSWORD_ACCOUNT_FIELD,
-    ROLE_ACCOUNT_FIELD,
-    ROLE_NON_EXISTING_ACCOUNT_FIELD,
-    USERID_ACCOUNT_FIELD,
-    USERID_NON_EXISTING_ACCOUNT_FIELD,
-    VERIFY_API_TLS_CERTIFICATE_PAR
+    NodeWithMastodonApiConfiguration
 )
 from feditest.protocols import (
     Account,
@@ -31,7 +24,141 @@ from feditest.protocols import (
 )
 from feditest.protocols.fediverse import FediverseNode
 from feditest.testplan import TestPlanConstellationNode, TestPlanNodeAccountField, TestPlanNodeNonExistingAccountField, TestPlanNodeParameter
-from feditest.utils import hostname_validate
+from feditest.utils import boolean_parse_validate, hostname_validate
+
+
+VERIFY_API_TLS_CERTIFICATE_PAR = TestPlanNodeParameter(
+    'verify_api_tls_certificate',
+    """If set to false, accessing the Mastodon API will be performed without checking TLS certificates.""",
+    validate=boolean_parse_validate
+)
+
+def _oauth_token_validate(candidate: str) -> str | None:
+    """
+    Validate a WordPress "Enable Mastodon Apps" app client API token. Avoids user input errors.
+    FIXME this is a wild guess and can be better.
+    """
+    candidate = candidate.strip()
+    return candidate if len(candidate)>10 else None
+
+
+def _userid_validate(candidate: str) -> str | None:
+    """
+    Validate a WordPress user name. Avoids user input errors.
+    FIXME this is a wild guess and can be better.
+    """
+    candidate = candidate.strip()
+    return candidate if re.match(r'[a-zA-Z0-9_]', candidate) else None
+
+
+USERID_ACCOUNT_FIELD = TestPlanNodeAccountField(
+        'userid',
+        """Mastodon userid for a user (e.g. "joe") (required).""",
+        _userid_validate
+)
+OAUTH_TOKEN_ACCOUNT_FIELD = TestPlanNodeAccountField(
+        'oauth_token',
+        """OAuth token of a user so the "Enable Mastodon apps" API can be invoked.""",
+        _oauth_token_validate
+)
+ROLE_ACCOUNT_FIELD = TestPlanNodeAccountField(
+        'role',
+        """A symbolic name for the Account as used by tests (optional).""",
+        lambda x: len(x)
+)
+
+USERID_NON_EXISTING_ACCOUNT_FIELD = TestPlanNodeNonExistingAccountField(
+        'userid',
+        """Mastodon userid for a non-existing user (e.g. "joe")  (required).""",
+        _userid_validate
+)
+ROLE_NON_EXISTING_ACCOUNT_FIELD = TestPlanNodeNonExistingAccountField(
+        'role',
+        """A symbolic name for the non-existing Account as used by tests (optional).""",
+        lambda x: len(x)
+)
+
+
+class WordPressAccount(AccountOnNodeWithMastodonAPI):
+    """
+    Compare with MastodonOAuthTokenAccount.
+    """
+    def __init__(self, role: str | None, userid: str, oauth_token: str | None):
+        """
+        The oauth_token may be None. In which case we dynamically obtain one.
+        """
+        super().__init__(role, userid)
+        self.userid = userid
+        self.oauth_token = oauth_token
+
+
+    @staticmethod
+    def create_from_account_info_in_testplan(account_info_in_testplan: dict[str, str | None], node_driver: NodeDriver):
+        """
+        Parses the information provided in an "account" dict of TestPlanConstellationNode
+        """
+        userid = USERID_ACCOUNT_FIELD.get_validate_from_or_raise(account_info_in_testplan, f'NodeDriver { node_driver }: ')
+        role = ROLE_ACCOUNT_FIELD.get_validate_from(account_info_in_testplan, f'NodeDriver { node_driver }: ')
+
+        oauth_token = OAUTH_TOKEN_ACCOUNT_FIELD.get_validate_from_or_raise(account_info_in_testplan, f'NodeDriver { node_driver }: ')
+        return WordPressAccount(role, userid, oauth_token)
+
+
+    @property
+    def actor_uri(self):
+        return f'https://{ self.node.hostname }/author/{ self.userid }'
+
+
+    def mastodon_user_client(self, node: NodeWithMastodonAPI) -> Mastodon:
+        if self._mastodon_user_client is None:
+            oauth_app = cast(MastodonOAuthApp,node._mastodon_oauth_app)
+            self._ensure_oauth_token(node, oauth_app.client_id)
+            client = Mastodon(
+                client_id = oauth_app.client_id,
+                client_secret=oauth_app.client_secret,
+                access_token=self.oauth_token,
+                api_base_url=oauth_app.api_base_url,
+                session=oauth_app.session
+            )
+            self._mastodon_user_client = client
+        return self._mastodon_user_client
+
+
+    def _ensure_oauth_token(self, node: NodeWithMastodonAPI, oauth_client_id: str) -> None:
+        """
+        Helper to dynamically provision an OAuth token if we don't have one yet.
+        """
+        if self.oauth_token:
+            return
+        real_node = cast(WordPressPlusActivityPubPluginNode, node)
+        self.oauth_token = real_node._provision_oauth_token_for(self.userid, oauth_client_id)
+
+
+class WordPressNonExistingAccount(NonExistingAccount):
+    def __init__(self, role: str | None, userid: str):
+        super().__init__(role)
+        self.userid = userid
+
+
+    @staticmethod
+    def create_from_non_existing_account_info_in_testplan(non_existing_account_info_in_testplan: dict[str, str | None], node_driver: NodeDriver):
+        """
+        Parses the information provided in an "non_existing_account" dict of TestPlanConstellationNode
+        """
+        userid = USERID_NON_EXISTING_ACCOUNT_FIELD.get_validate_from_or_raise(non_existing_account_info_in_testplan, f'NodeDriver { node_driver }: ')
+        role = ROLE_ACCOUNT_FIELD.get_validate_from(non_existing_account_info_in_testplan, f'NodeDriver { node_driver }: ')
+
+        return WordPressNonExistingAccount(role, userid)
+
+
+    @property
+    def webfinger_uri(self):
+        return f'acct:{ self.userid }@{ self.node.hostname }'
+
+
+    @property
+    def actor_uri(self):
+        return f'https://{ self.node.hostname }/users/{ self.userid }'
 
 
 class WordPressPlusActivityPubPluginNode(NodeWithMastodonAPI):
@@ -44,6 +171,13 @@ class WordPressPlusActivityPubPluginNode(NodeWithMastodonAPI):
             if m.group(1) == self._config.hostname:
                 return m.group(2)
         raise ValueError( f'Cannot find actor at this node: { actor_uri }' )
+
+
+    def _provision_oauth_token_for(self, userid: str, oauth_client_id: str):
+        ret = self.prompt_user(f'Enter the OAuth token for the Mastodon API for user "{ userid }"'
+                              + f' on constellation role "{ self.rolename }" (user field "{ OAUTH_TOKEN_ACCOUNT_FIELD }"): ',
+                              parse_validate=_oauth_token_validate)
+        return ret
 
 
 class WordPressPlusActivityPubPluginSaasNodeDriver(NodeDriver):
@@ -59,7 +193,7 @@ class WordPressPlusActivityPubPluginSaasNodeDriver(NodeDriver):
     # Python 3.12 @override
     @staticmethod
     def test_plan_node_account_fields() -> list[TestPlanNodeAccountField]:
-        return [ USERID_ACCOUNT_FIELD, EMAIL_ACCOUNT_FIELD, PASSWORD_ACCOUNT_FIELD, OAUTH_TOKEN_ACCOUNT_FIELD, ROLE_ACCOUNT_FIELD ]
+        return [ USERID_ACCOUNT_FIELD, OAUTH_TOKEN_ACCOUNT_FIELD, ROLE_ACCOUNT_FIELD ]
 
 
     # Python 3.12 @override
@@ -70,24 +204,25 @@ class WordPressPlusActivityPubPluginSaasNodeDriver(NodeDriver):
 
     # Python 3.12 @override
     def create_configuration_account_manager(self, rolename: str, test_plan_node: TestPlanConstellationNode) -> tuple[NodeConfiguration, AccountManager | None]:
-        app = test_plan_node.parameter_or_raise(APP_PAR, { APP_PAR.name:  'Mastodon' }) # Let user give a more descriptive name if they want to
+        app = test_plan_node.parameter_or_raise(APP_PAR, { APP_PAR.name:  'WordPress + ActivityPub plugin' }) # Let user give a more descriptive name if they want to
         app_version = test_plan_node.parameter(APP_VERSION_PAR)
         hostname = test_plan_node.parameter_or_raise(HOSTNAME_PAR)
         verify_tls_certificate = test_plan_node.parameter_or_raise(VERIFY_API_TLS_CERTIFICATE_PAR, { VERIFY_API_TLS_CERTIFICATE_PAR.name: 'true' })
 
         if not hostname:
-            hostname = self.prompt_user(f'Enter the hostname for the Mastodon Node of constellation role "{ rolename }" (node parameter "hostname"): ',
+            hostname = self.prompt_user(f'Enter the hostname for the WordPress + ActivityPub plugin Node of constellation role "{ rolename }"'
+                                        + f' (node parameter "{ HOSTNAME_PAR }"): ',
                                         parse_validate=hostname_validate)
 
         accounts : list[Account] = []
         if test_plan_node.accounts:
             for account_info in test_plan_node.accounts:
-                accounts.append(MastodonAccount.create_from_account_info_in_testplan(account_info, self))
+                accounts.append(WordPressAccount.create_from_account_info_in_testplan(account_info, self))
 
         non_existing_accounts : list[NonExistingAccount] = []
         if test_plan_node.non_existing_accounts:
             for non_existing_account_info in test_plan_node.non_existing_accounts:
-                non_existing_accounts.append(MastodonNonExistingAccount.create_from_non_existing_account_info_in_testplan(non_existing_account_info, self))
+                non_existing_accounts.append(WordPressNonExistingAccount.create_from_non_existing_account_info_in_testplan(non_existing_account_info, self))
 
         return (
             NodeWithMastodonApiConfiguration(

--- a/src/feditest/nodedrivers/wordpress/__init__.py
+++ b/src/feditest/nodedrivers/wordpress/__init__.py
@@ -88,8 +88,8 @@ class WordPressAccount(AccountOnNodeWithMastodonAPI):
         The oauth_token may be None. In which case we dynamically obtain one.
         """
         super().__init__(role, userid)
-        self.userid = userid
         self.oauth_token = oauth_token
+        self._mastodon_user_client: Mastodon | None = None # Allocated as needed
 
 
     @staticmethod
@@ -110,6 +110,7 @@ class WordPressAccount(AccountOnNodeWithMastodonAPI):
 
 
     def mastodon_user_client(self, node: NodeWithMastodonAPI) -> Mastodon:
+
         if self._mastodon_user_client is None:
             oauth_app = cast(MastodonOAuthApp,node._mastodon_oauth_app)
             self._ensure_oauth_token(node, oauth_app.client_id)

--- a/src/feditest/nodedrivers/wordpress/ubos.py
+++ b/src/feditest/nodedrivers/wordpress/ubos.py
@@ -3,29 +3,47 @@
 
 from typing import cast
 
-from feditest.nodedrivers.mastodon import (
-    MastodonAccount,
-    MastodonNonExistingAccount,
-    EMAIL_ACCOUNT_FIELD,
+from feditest.nodedrivers.mastodon.ubos import MastodonUbosNodeConfiguration
+from feditest.nodedrivers.wordpress import (
     OAUTH_TOKEN_ACCOUNT_FIELD,
-    PASSWORD_ACCOUNT_FIELD,
     ROLE_ACCOUNT_FIELD,
     ROLE_NON_EXISTING_ACCOUNT_FIELD,
     USERID_ACCOUNT_FIELD,
-    USERID_NON_EXISTING_ACCOUNT_FIELD
+    USERID_NON_EXISTING_ACCOUNT_FIELD,
+    WordPressAccount,
+    WordPressNonExistingAccount,
+    WordPressPlusActivityPubPluginNode
 )
-from feditest.nodedrivers.mastodon.ubos import MastodonUbosAccountManager, MastodonUbosNodeConfiguration
-from feditest.nodedrivers.wordpress import WordPressPlusActivityPubPluginNode
 from feditest.protocols import (
     Account,
-    NonExistingAccount,
     AccountManager,
+    DefaultAccountManager,
+    NonExistingAccount,
     Node,
     NodeConfiguration
 )
 from feditest.reporting import trace
 from feditest.testplan import TestPlanConstellationNode, TestPlanNodeAccountField, TestPlanNodeNonExistingAccountField
 from feditest.ubos import UbosNodeConfiguration, UbosNodeDriver
+
+
+
+class WordPressUbosAccountManager(DefaultAccountManager):
+    """
+    Knows how to provision new accounts in WordPress
+    """
+    # Python 3.12 @override
+    def set_node(self, node: Node) -> None:
+        """
+        We override this so we can insert the admin account in the list of accounts, now that the Node has been instantiated.
+        """
+        super().set_node(node)
+
+        if not self._accounts_allocated_to_role and not self._accounts_not_allocated_to_role:
+            config = cast(UbosNodeConfiguration, node.config)
+            admin_account = WordPressAccount(None, config.admin_userid, None)
+            admin_account.set_node(node)
+            self._accounts_not_allocated_to_role.append(admin_account)
 
 
 class WordPressPlusActivityPubPluginUbosNode(WordPressPlusActivityPubPluginNode):
@@ -56,6 +74,33 @@ class WordPressPlusActivityPubPluginUbosNode(WordPressPlusActivityPubPluginNode)
         node_driver.remove_cert_from_trust_store_via(root_cert, config.rshcmd)
 
 
+    # Python 3.12 @override
+    def _provision_oauth_token_for(self, userid: str, oauth_client_id: str):
+        # Code from here: https://wordpress.org/support/topic/programmatically-obtaining-oauth-token-for-testing/
+        # $desired_token = '123';
+        # $user_id = 1;
+        # $oauth = new Enable_Mastodon_Apps\Mastodon_OAuth();
+        # $oauth->get_token_storage()->setAccessToken( $desired_token, $app->get_client_id(), $user_id, time() + HOUR_IN_SECONDS, $app->get_scopes() );
+
+        config = cast(UbosNodeConfiguration, self.config)
+        node_driver = cast(WordPressPlusActivityPubPluginUbosNodeDriver, self.node_driver)
+
+        php_script = f"""
+<?php
+$_SERVER['HTTP_HOST'] = '{ self.hostname }';
+
+include 'wp-load.php';
+
+$oauth = new Enable_Mastodon_Apps\Mastodon_OAuth();
+$oauth->get_token_storage()->setAccessToken( "11223344", "{ oauth_client_id }", "{ userid }", time() + HOUR_IN_SECONDS, 'read write follow push' );
+"""
+        dir = f'/ubos/http/sites/{ config.siteid }'
+        cmd = f'cd { dir } && sudo sudo -u http php' # from user ubosdev -> root -> http
+
+        if node_driver._exec_shell(cmd, config.rshcmd, stdin_content=php_script).returncode:
+            raise Exception(self, f"Failed to create OAuth token for user { userid }, cmd: { cmd }")
+
+
 class WordPressPlusActivityPubPluginUbosNodeDriver(UbosNodeDriver):
     """
     Knows how to instantiate Mastodon via UBOS.
@@ -63,7 +108,7 @@ class WordPressPlusActivityPubPluginUbosNodeDriver(UbosNodeDriver):
     # Python 3.12 @override
     @staticmethod
     def test_plan_node_account_fields() -> list[TestPlanNodeAccountField]:
-        return [ USERID_ACCOUNT_FIELD, EMAIL_ACCOUNT_FIELD, PASSWORD_ACCOUNT_FIELD, OAUTH_TOKEN_ACCOUNT_FIELD, ROLE_ACCOUNT_FIELD ]
+        return [ USERID_ACCOUNT_FIELD, OAUTH_TOKEN_ACCOUNT_FIELD, ROLE_ACCOUNT_FIELD ]
 
 
     # Python 3.12 @override
@@ -77,12 +122,12 @@ class WordPressPlusActivityPubPluginUbosNodeDriver(UbosNodeDriver):
         accounts : list[Account] = []
         if test_plan_node.accounts:
             for account_info in test_plan_node.accounts:
-                accounts.append(MastodonAccount.create_from_account_info_in_testplan(account_info, self))
+                accounts.append(WordPressAccount.create_from_account_info_in_testplan(account_info, self))
 
         non_existing_accounts : list[NonExistingAccount] = []
         if test_plan_node.non_existing_accounts:
             for non_existing_account_info in test_plan_node.non_existing_accounts:
-                non_existing_accounts.append(MastodonNonExistingAccount.create_from_non_existing_account_info_in_testplan(non_existing_account_info, self))
+                non_existing_accounts.append(WordPressNonExistingAccount.create_from_non_existing_account_info_in_testplan(non_existing_account_info, self))
 
         # Once has the Node has been instantiated (we can't do that here yet): if the user did not specify at least one Account, we add the admin account
 
@@ -102,7 +147,7 @@ class WordPressPlusActivityPubPluginUbosNodeDriver(UbosNodeDriver):
                 defaults = {
                     'app' : 'WordPress + ActivityPub plugin'
                 }),
-            MastodonUbosAccountManager(accounts, non_existing_accounts)
+            WordPressUbosAccountManager(accounts, non_existing_accounts)
         )
 
     # Python 3.12 @override

--- a/src/feditest/ubos/__init__.py
+++ b/src/feditest/ubos/__init__.py
@@ -494,7 +494,7 @@ class UbosNodeDriver(NodeDriver):
         cmd += ' --newcontext ""'
         cmd += f' --in "{ config.backupfile }"'
 
-        if self._exec_shell(cmd).returncode:
+        if self._exec_shell(cmd, config.rshcmd).returncode:
             raise UbosAdminException(self, cmd)
 
 


### PR DESCRIPTION
WordPress needs to have its own Account implementation -- different path than Mastodon
Added OAuth token account provisioning code from Enable_Mastodon_Apps developer
Throw Exception if mastodon_user_client was about to return None