### PR TITLE
Allow registry to generate certs for hostnames specified in the TestPlan

### DIFF
--- a/src/feditest/protocols/__init__.py
+++ b/src/feditest/protocols/__init__.py
@@ -458,6 +458,8 @@ class Node(ABC):
 
 
     def __str__(self) -> str:
+        if self._config.hostname:
+            return f'"{ type(self).__name__}", hostname "{ self._config.hostname }" in constellation role "{self.rolename}"'
         return f'"{ type(self).__name__}" in constellation role "{self.rolename}"'
 
 

--- a/src/feditest/registry.py
+++ b/src/feditest/registry.py
@@ -169,7 +169,9 @@ class Registry(msgspec.Struct):
         trace(f'Registry.obtain_hostinfo({ host }) with domain { self.ca.domain }')
         ret = self.hosts.get(host)
         if ret is None:
-            raise Exception(f'Unknown host: {host}')
+            # An externally specified hostname: add to set of known hosts
+            ret = RegistryHostInfo(host=host)
+            self.hosts[host] = ret
 
         host_key: rsa.RSAPrivateKey
         if ret.key is None:


### PR DESCRIPTION
Also better Node toString